### PR TITLE
Fix RFC 8785 reference in spec

### DIFF
--- a/spec/references.md
+++ b/spec/references.md
@@ -42,3 +42,5 @@ Normative references define binding requirements; informative references provide
 - Normative references MUST be followed to ensure protocol compliance and interoperability.  
 - Informative references MAY be used to enhance implementations with additional features, metadata, or compliance with legal frameworks.  
 - Future revisions of this specification MAY expand or refine this references list as new standards and regulations emerge.
+
+[RFC 8785]: https://www.rfc-editor.org/rfc/rfc8785

--- a/spec/security.md
+++ b/spec/security.md
@@ -62,4 +62,4 @@ Implementers MUST consider the following attack vectors:
 
 ---
 
-[RF C8785]: https://www.rfc-editor.org/rfc/rfc8785
+[RFC 8785]: https://www.rfc-editor.org/rfc/rfc8785


### PR DESCRIPTION
## Summary
- correct the RFC 8785 footnote label in the security considerations
- add a reference definition for RFC 8785 to the references appendix

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68c8e55ffccc832d828d62a19204bfd8