### PR TITLE
Document NFT token identifiers in anchors

### DIFF
--- a/spec/anchoring.md
+++ b/spec/anchoring.md
@@ -9,9 +9,10 @@ This provides cryptographic proof that the Codex Entry existed at or before a sp
 
 - Every Codex Entry MUST include an `anchor` object when immutability and timestamp proofs are required.  
 - Anchors MUST reference:
-  - `chain`: a [CAIP-2] compliant blockchain identifier.  
-  - `tx_hash`: the transaction hash containing the anchor payload.  
-  - `hash_alg`: the algorithm used to produce the Codex Entry hash (e.g., SHA-256).  
+  - `chain`: a [CAIP-2] compliant blockchain identifier.
+  - `tx_hash`: the transaction hash containing the anchor payload.
+  - `hash_alg`: the algorithm used to produce the Codex Entry hash (e.g., SHA-256).
+- Anchors MAY include a `token_id` when referencing a specific on-chain asset; this field is REQUIRED for NFT-based anchors.
 
 - The Codex Entry content MUST be hashed and included in the blockchain transaction, either directly or via a Merkle root.  
 - Anchors MUST be reproducible: the same Codex Entry must yield the same anchor hash when re-hashed.  
@@ -41,17 +42,30 @@ Other chains MAY be supported, including but not limited to:
 
 ### 5.3.1 NFT Anchoring
 
-Implementations MAY use Non-Fungible Tokens (NFTs) as anchor carriers.  
+Implementations MAY use Non-Fungible Tokens (NFTs) as anchor carriers.
 In this model, the Codex Entry hash is embedded in the NFT’s metadata or in the minting transaction payload.
+When an NFT is used, the `token_id` field in the anchor object becomes mandatory and MUST reference the on-chain token identifier.
 
 Anchors using NFTs MUST declare:
 
-- `chain`: a [CAIP-2] blockchain identifier for the NFT’s chain.  
-- `tx_hash`: the transaction hash of the NFT minting or transfer that includes the Codex Entry hash.  
-- `hash_alg`: the algorithm used to produce the Codex Entry hash.  
-- `token_id`: the unique identifier of the NFT on-chain.  
+- `chain`: a [CAIP-2] blockchain identifier for the NFT’s chain.
+- `tx_hash`: the transaction hash of the NFT minting or transfer that includes the Codex Entry hash.
+- `hash_alg`: the algorithm used to produce the Codex Entry hash.
+- `token_id`: the unique identifier of the NFT on-chain.
 
-Example:
+Examples:
+
+Non-NFT anchor:
+
+```json
+"anchor": {
+  "chain": "eip155:1",
+  "tx_hash": "0xdef456...",
+  "hash_alg": "SHA256"
+}
+```
+
+NFT anchor:
 
 ```json
 "anchor": {

--- a/spec/appendix-b-schema.md
+++ b/spec/appendix-b-schema.md
@@ -126,7 +126,12 @@ The schema reflects all required and optional fields described in Section 3 (Dat
       "properties": {
         "chain": {"type": "string", "description": "CAIP-2 blockchain identifier."},
         "tx_hash": {"type": "string", "description": "Transaction hash referencing the anchor."},
-        "hash_alg": {"type": "string", "enum": ["SHA256", "SHA3-256"]}
+        "hash_alg": {"type": "string", "enum": ["SHA256", "SHA3-256"]},
+        "token_id": {
+          "type": "string",
+          "pattern": "^(0x[a-fA-F0-9]+|[A-Za-z0-9][A-Za-z0-9._:-]*)$",
+          "description": "Optional NFT identifier; accepts 0x-prefixed hex or alphanumeric strings with separators (:, -, _, .)."
+        }
       }
     },
     "signatures": {


### PR DESCRIPTION
## Summary
- add an optional `token_id` property to the anchor schema with validation for common NFT identifiers
- clarify when `token_id` is required within the anchoring specification and expand examples for NFT and non-NFT anchors

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68c8e80f2c20832db2aeef240c57ec83