### PR TITLE
Document Google Cloud Storage support

### DIFF
--- a/spec/appendix-a-flows.md
+++ b/spec/appendix-a-flows.md
@@ -47,7 +47,20 @@ These examples are non-normative and are intended to help implementers understan
 
 ---
 
-## A.4 Multi-Sig Control Flow
+## A.4 Google Cloud Storage Example
+
+1. File is uploaded to Google Cloud Storage (GCS), yielding object metadata with `crc32c` and `md5Hash` values.
+2. Codex Entry includes:
+   - `storage.protocol = "gcs"`
+   - `storage.integrity_proof = "ni:///sha-256;..."`
+   - `storage.location` with bucket location (e.g., `us-central1`), legal jurisdiction (e.g., `US/CA`), and `provider = "Google Cloud"`.
+   - Optional recording of the object's `crc32c` for auditors.
+3. Entry is signed and anchored on Stellar.
+4. Verifier fetches object metadata via the GCS API, recomputes the SHA-256 digest, and validates the anchor.
+
+---
+
+## A.5 Multi-Sig Control Flow
 
 1. Organization defines a policy: 2-of-3 required for encryption/decryption.  
 2. Codex Entry includes `encryption.policy` and `encryption.public_keys`.  
@@ -58,7 +71,7 @@ These examples are non-normative and are intended to help implementers understan
 
 ---
 
-## A.5 Revision Chain Flow
+## A.6 Revision Chain Flow
 
 1. Original file is recorded as Codex Entry `id=UUID1`.  
 2. Later, a revised version is created as Codex Entry `id=UUID2`, with `previous_id=UUID1`.  

--- a/spec/appendix-b-schema.md
+++ b/spec/appendix-b-schema.md
@@ -43,8 +43,8 @@ The schema reflects all required and optional fields described in Section 3 (Dat
       "properties": {
         "protocol": {
           "type": "string",
-          "enum": ["ipfs", "s3", "azureblob", "gcp", "ftp", "local"],
-          "description": "Storage backend protocol."
+          "enum": ["ipfs", "s3", "azureblob", "gcs", "ftp", "local"],
+          "description": "Storage backend protocol (IPFS, S3, Azure Blob, Google Cloud Storage, FTP, Local)."
         },
         "integrity_proof": {
           "type": "string",

--- a/spec/certificates.md
+++ b/spec/certificates.md
@@ -137,14 +137,14 @@ A single Codex Entry can generate multiple certificates for different consumers:
   "issuer": "did:example:org123",
   "subject": "did:example:asset789",
   "storage": {
-    "protocol": "ipfs",
+    "protocol": "gcs",
     "integrity_proof": "ni:///sha-256;4nq34kaf9djf23...",
     "media_type": "application/pdf",
     "size_bytes": 204800,
     "location": {
-      "region": "eu-west-1",
-      "jurisdiction": "EU/DE",
-      "provider": "AWS"
+      "region": "us-central1",
+      "jurisdiction": "US/CA",
+      "provider": "Google Cloud"
     }
   },
   "anchor": {
@@ -184,14 +184,14 @@ A single Codex Entry can generate multiple certificates for different consumers:
     "codexEntry": {
       "protocolVersion": "1.0.0",
       "storage": {
-        "protocol": "ipfs",
+        "protocol": "gcs",
         "integrityProof": "ni:///sha-256;4nq34kaf9djf23...",
         "mediaType": "application/pdf",
         "sizeBytes": 204800,
         "location": {
-          "region": "eu-west-1",
-          "jurisdiction": "EU/DE",
-          "provider": "AWS"
+          "region": "us-central1",
+          "jurisdiction": "US/CA",
+          "provider": "Google Cloud"
         }
       },
       "anchor": {

--- a/spec/data-model.md
+++ b/spec/data-model.md
@@ -15,14 +15,14 @@ A Codex Entry MUST be expressed as JSON and include the following fields:
   "previous_id": "uuid-v4",
   "version": "1.0.0",
   "storage": {
-    "protocol": "ipfs|s3|azureblob|gcp|ftp|local",
+    "protocol": "ipfs|s3|azureblob|gcs|ftp|local",
     "integrity_proof": "ni:///sha-256;<digest>",
     "media_type": "application/pdf",
     "size_bytes": 204800,
     "location": {
-      "region": "eu-west-1",
-      "jurisdiction": "EU/DE",
-      "provider": "AWS"
+      "region": "us-central1",
+      "jurisdiction": "US/CA",
+      "provider": "Google Cloud"
     }
   },
   "encryption": {

--- a/spec/reference-implementation.md
+++ b/spec/reference-implementation.md
@@ -11,7 +11,7 @@ This section is informative and does not define new normative requirements.
 ## 12.1 Goals of the Reference Implementation
 
 - Demonstrate the end-to-end workflow of creating, signing, anchoring, and verifying Codex Entries.  
-- Provide working adapters for common storage systems (IPFS, S3, Azure Blob).  
+- Provide working adapters for common storage systems (IPFS, S3, Google Cloud Storage, Azure Blob).
 - Showcase blockchain anchoring with Stellar as the primary example.  
 - Offer CLI and API tools to simplify integration.  
 - Act as a foundation for conformance testing.  
@@ -32,8 +32,8 @@ The reference implementation SHOULD include:
   - Integration with external storage adapters.  
   - Middleware for certificate issuance.  
 
-- **Storage Adapters**  
-  - Reference adapters for IPFS, S3, and Azure Blob.  
+- **Storage Adapters**
+  - Reference adapters for IPFS, S3, Google Cloud Storage, and Azure Blob.
   - Mock adapters for testing (local filesystem, memory).  
 
 - **Verifier Library**  

--- a/spec/storage-adapters.md
+++ b/spec/storage-adapters.md
@@ -31,19 +31,25 @@ Adapters MAY also implement:
 
 ## 4.2 Supported Backends
 
-The reference implementation MUST include at least two adapters:  
+The reference implementation MUST include at least three adapters:
 
-- **IPFS**:  
-  - Proof: CID (Content Identifier).  
-  - Expressed as `ipfs://<cid>` or `ni:///sha-256;<digest>`.  
-  - Location: IPFS gateway region or pinning service jurisdiction.  
+- **IPFS**:
+  - Proof: CID (Content Identifier).
+  - Expressed as `ipfs://<cid>` or `ni:///sha-256;<digest>`.
+  - Location: IPFS gateway region or pinning service jurisdiction.
 
-- **S3-Compatible (AWS, MinIO, etc.)**:  
-  - Proof: ETag checksum.  
-  - Location: `region`, `jurisdiction`, and provider (`AWS`, `MinIO`).  
-  - Media type and size MUST be provided.  
+- **S3-Compatible (AWS, MinIO, etc.)**:
+  - Proof: ETag checksum.
+  - Location: `region`, `jurisdiction`, and provider (`AWS`, `MinIO`).
+  - Media type and size MUST be provided.
 
-Implementations SHOULD also support:  
+- **Google Cloud Storage (GCS)**:
+  - Proof: The adapter MUST compute a SHA-256 digest of the object and express it as `ni:///sha-256;<digest>`.
+  - The adapter MUST capture the canonical `crc32c` checksum returned by GCS metadata when available.
+  - Location: MUST report the bucket location (e.g., `us-central1`), the governing jurisdiction (e.g., `US/CA`), and set `provider` to `Google Cloud`.
+  - Media type and size MUST be provided.
+
+Implementations SHOULD also support:
 
 - **Azure Blob Storage**:  
   - Proof: MD5/CRC64 checksum.  

--- a/spec/terminology.md
+++ b/spec/terminology.md
@@ -5,7 +5,7 @@ The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHALL**, **SHALL NOT**,
 are to be interpreted as described in [RFC 2119].
 
 - **Codex Entry**: A structured, signed data object that encapsulates integrity proofs, storage references, and anchors. It is the fundamental unit of the Lockb0x Protocol.  
-- **Storage Adapter**: A module or function that interfaces with an external storage system (e.g., IPFS, S3, Azure Blob, FTP/SFTP) and produces verifiable proofs of storage.  
+- **Storage Adapter**: A module or function that interfaces with an external storage system (e.g., IPFS, S3, Google Cloud Storage, Azure Blob, FTP/SFTP) and produces verifiable proofs of storage.
 - **Anchor**: A blockchain transaction or equivalent immutable record that cryptographically attests to the existence of a Codex Entry at a specific point in time.  
 - **Verifier**: A tool or process that checks the validity of a Codex Entry by verifying signatures, integrity proofs, storage claims, and anchors.  
 - **Certificate**: A human- or machine-readable document generated from a Codex Entry that provides evidence of integrity, custodianship, and anchoring. Certificates MAY be represented as JSON objects or W3C Verifiable Credentials.  


### PR DESCRIPTION
## Summary
- add Google Cloud Storage to the Codex Entry model and JSON schema enumerations
- define Google Cloud Storage adapter requirements and update non-normative examples/test vectors accordingly
- refresh terminology and reference implementation guidance to reflect the expanded backend list

## Testing
- not run (documentation updates)


------
https://chatgpt.com/codex/tasks/task_e_68c8e952ea18832dae5a7b136330774d