### PR TITLE
Implement Stellar anchoring service

### DIFF
--- a/Lockb0x.Anchor.Stellar/AnchorTransactionContext.cs
+++ b/Lockb0x.Anchor.Stellar/AnchorTransactionContext.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Lockb0x.Anchor.Stellar;
+
+/// <summary>
+/// Provides the data required to construct a Stellar transaction envelope.
+/// </summary>
+public sealed record AnchorTransactionContext(
+    StellarNetworkOptions Network,
+    StellarMemo Memo,
+    ReadOnlyMemory<byte> EntryHash,
+    string PublicKey);

--- a/Lockb0x.Anchor.Stellar/Class1.cs
+++ b/Lockb0x.Anchor.Stellar/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace Lockb0x.Anchor.Stellar;
-
-public class Class1
-{
-
-}

--- a/Lockb0x.Anchor.Stellar/HttpStellarHorizonClient.cs
+++ b/Lockb0x.Anchor.Stellar/HttpStellarHorizonClient.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Lockb0x.Anchor.Stellar;
+
+/// <summary>
+/// Horizon client backed by HTTP requests to a Stellar node.
+/// </summary>
+public sealed class HttpStellarHorizonClient : IStellarHorizonClient
+{
+    private readonly HttpClient _httpClient;
+
+    public HttpStellarHorizonClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+    }
+
+    public async Task<StellarTransactionRecord?> FindTransactionByMemoAsync(StellarMemo memo, StellarNetworkOptions network, CancellationToken cancellationToken)
+    {
+        if (memo is null)
+        {
+            throw new ArgumentNullException(nameof(memo));
+        }
+
+        var uri = BuildUri(network.HorizonEndpoint, $"transactions?memo={Uri.EscapeDataString(memo.ToBase64())}&limit=1&order=desc");
+        using var response = await _httpClient.GetAsync(uri, cancellationToken).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        using var document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken).ConfigureAwait(false);
+        if (!document.RootElement.TryGetProperty("_embedded", out var embedded) ||
+            !embedded.TryGetProperty("records", out var records) ||
+            records.GetArrayLength() == 0)
+        {
+            return null;
+        }
+
+        return ParseTransaction(records[0]);
+    }
+
+    public async Task<StellarTransactionRecord?> GetTransactionAsync(string transactionHash, StellarNetworkOptions network, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(transactionHash))
+        {
+            throw new ArgumentException("Transaction hash must be provided.", nameof(transactionHash));
+        }
+
+        var uri = BuildUri(network.HorizonEndpoint, $"transactions/{transactionHash}");
+        using var response = await _httpClient.GetAsync(uri, cancellationToken).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        using var document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return ParseTransaction(document.RootElement);
+    }
+
+    public async Task<StellarTransactionRecord> SubmitTransactionAsync(StellarSubmitTransactionRequest request, CancellationToken cancellationToken)
+    {
+        if (request is null)
+        {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        if (string.IsNullOrWhiteSpace(request.EnvelopeXdr))
+        {
+            throw new StellarAnchorException("anchor.envelope_missing", "A signed transaction envelope (base64 XDR) is required to submit to Horizon.");
+        }
+
+        var uri = BuildUri(request.Network.HorizonEndpoint, "transactions");
+        using var content = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["tx"] = request.EnvelopeXdr!
+        });
+
+        using var response = await _httpClient.PostAsync(uri, content, cancellationToken).ConfigureAwait(false);
+        var payload = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new StellarAnchorException("anchor.horizon_error", $"Horizon rejected the transaction: {(int)response.StatusCode} {payload}");
+        }
+
+        using var document = JsonDocument.Parse(payload);
+        if (!document.RootElement.TryGetProperty("hash", out var hashProperty) || hashProperty.ValueKind != JsonValueKind.String)
+        {
+            throw new StellarAnchorException("anchor.horizon_unexpected", "Horizon response did not contain a transaction hash.");
+        }
+
+        var hash = hashProperty.GetString()!;
+        var record = await GetTransactionAsync(hash, request.Network, cancellationToken).ConfigureAwait(false);
+        if (record is null)
+        {
+            // Fall back to minimal record using memo bytes when Horizon does not return the transaction immediately.
+            return new StellarTransactionRecord(hash, request.Memo.Value.ToArray(), request.Memo.MemoType, request.RequestedAt ?? DateTimeOffset.UtcNow, request.PublicKey);
+        }
+
+        return record;
+    }
+
+    private static Uri BuildUri(Uri baseUri, string relativePath)
+    {
+        if (!baseUri.AbsoluteUri.EndsWith('/'))
+        {
+            baseUri = new Uri(baseUri.AbsoluteUri + '/');
+        }
+
+        return new Uri(baseUri, relativePath);
+    }
+
+    private static StellarTransactionRecord? ParseTransaction(JsonElement element)
+    {
+        if (!element.TryGetProperty("hash", out var hashElement) || hashElement.ValueKind != JsonValueKind.String)
+        {
+            return null;
+        }
+
+        var memoType = element.TryGetProperty("memo_type", out var memoTypeElement) && memoTypeElement.ValueKind == JsonValueKind.String
+            ? memoTypeElement.GetString() ?? "hash"
+            : "hash";
+
+        byte[] memoBytes = Array.Empty<byte>();
+        if (element.TryGetProperty("memo", out var memoElement) && memoElement.ValueKind == JsonValueKind.String)
+        {
+            var memoValue = memoElement.GetString();
+            if (!string.IsNullOrEmpty(memoValue))
+            {
+                memoBytes = memoType switch
+                {
+                    "text" => Encoding.UTF8.GetBytes(memoValue),
+                    _ => Convert.FromBase64String(memoValue)
+                };
+            }
+        }
+
+        DateTimeOffset? ledgerCloseTime = null;
+        if (element.TryGetProperty("ledger_close_time", out var timeElement) && timeElement.ValueKind == JsonValueKind.String)
+        {
+            if (DateTimeOffset.TryParse(timeElement.GetString(), out var parsed))
+            {
+                ledgerCloseTime = parsed;
+            }
+        }
+
+        var sourceAccount = element.TryGetProperty("source_account", out var accountElement) && accountElement.ValueKind == JsonValueKind.String
+            ? accountElement.GetString()
+            : null;
+
+        return new StellarTransactionRecord(hashElement.GetString()!, memoBytes, memoType, ledgerCloseTime, sourceAccount);
+    }
+}

--- a/Lockb0x.Anchor.Stellar/IClock.cs
+++ b/Lockb0x.Anchor.Stellar/IClock.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace Lockb0x.Anchor.Stellar;
+
+public interface IClock
+{
+    DateTimeOffset UtcNow { get; }
+}

--- a/Lockb0x.Anchor.Stellar/IMemoStrategy.cs
+++ b/Lockb0x.Anchor.Stellar/IMemoStrategy.cs
@@ -1,0 +1,15 @@
+using Lockb0x.Core.Canonicalization;
+using Lockb0x.Core.Models;
+
+namespace Lockb0x.Anchor.Stellar;
+
+/// <summary>
+/// Produces Stellar memo payloads for Codex Entry anchors.
+/// </summary>
+public interface IMemoStrategy
+{
+    /// <summary>
+    /// Creates a deterministic memo payload for the supplied Codex Entry and Stellar account.
+    /// </summary>
+    StellarMemo CreateMemo(CodexEntry entry, string stellarPublicKey, IJsonCanonicalizer canonicalizer);
+}

--- a/Lockb0x.Anchor.Stellar/IStellarAnchorService.cs
+++ b/Lockb0x.Anchor.Stellar/IStellarAnchorService.cs
@@ -1,151 +1,38 @@
+using System.Threading;
 using System.Threading.Tasks;
-using Lockb0x.Core;
+using Lockb0x.Core.Models;
 
 namespace Lockb0x.Anchor.Stellar;
 
+/// <summary>
+/// Provides anchoring and verification helpers for committing Codex Entries to the Stellar ledger.
+/// </summary>
 public interface IStellarAnchorService
 {
-    Task<AnchorProof> AnchorAsync(CodexEntry entry, string network = "testnet", string? stellarPublicKey = null);
-    Task<bool> VerifyAnchorAsync(AnchorProof anchor, CodexEntry entry, string network = "testnet", string? stellarPublicKey = null);
-    Task<string> GetTransactionUrlAsync(AnchorProof anchor, string network = "testnet");
-}
+    /// <summary>
+    /// Anchors the supplied Codex Entry on the configured Stellar network and returns the resulting proof.
+    /// </summary>
+    Task<AnchorProof> AnchorAsync(
+        CodexEntry entry,
+        string network = "testnet",
+        string? stellarPublicKey = null,
+        CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Verifies that the supplied anchor proof exists on the configured Stellar network and matches the Codex Entry hash.
+    /// </summary>
+    Task<bool> VerifyAnchorAsync(
+        AnchorProof anchor,
+        CodexEntry entry,
+        string network = "testnet",
+        string? stellarPublicKey = null,
+        CancellationToken cancellationToken = default);
 
-public class StellarAnchorService : IStellarAnchorService
-{
-
-    public async Task<AnchorProof> AnchorAsync(CodexEntry entry, string network = "testnet", string? stellarPublicKey = null)
-    {
-        // 1. Hash the CodexEntry (canonicalized JSON, SHA-256)
-        byte[] hash = ComputeEntryHash(entry);
-        string hashHex = BitConverter.ToString(hash).Replace("-", string.Empty).ToLowerInvariant();
-
-        // 2. Generate Stellar memo identifier (MD5 + public key truncated to 28 bytes)
-        string memoHex = GenerateStellarMemo(entry, stellarPublicKey ?? "GABC123DEFAULTKEY");
-
-        // 3. Build a Stellar transaction with the memo (stubbed for dry-run/testnet)
-        string txHash = IsDryRun(network)
-            ? $"dryrun-{Guid.NewGuid()}"
-            : "TODO: Implement real Stellar transaction submission";
-
-        // 4. Populate AnchorProof
-        var proof = new AnchorProof
-        {
-            ChainId = GetCaip2ChainId(network),
-            TxHash = txHash,
-            HashAlgorithm = "sha-256",
-            AnchoredAt = DateTimeOffset.UtcNow
-        };
-
-        // 5. TODO: Integrate with Stellar SDK for real transaction submission with memoHex
-
-        return await Task.FromResult(proof);
-    }
-
-
-    public async Task<bool> VerifyAnchorAsync(AnchorProof anchor, CodexEntry entry, string network = "testnet", string? stellarPublicKey = null)
-    {
-        // 1. Hash the CodexEntry
-        byte[] hash = ComputeEntryHash(entry);
-        string hashHex = BitConverter.ToString(hash).Replace("-", string.Empty).ToLowerInvariant();
-
-        // 2. For dry-run/testnet, just check txHash format
-        if (IsDryRun(network))
-        {
-            return await Task.FromResult(anchor.TxHash.StartsWith("dryrun-"));
-        }
-
-        // 3. TODO: Query Stellar Horizon for transaction, check memo hash matches computed memo
-        // The memo should match the result of GenerateStellarMemo(entry, stellarPublicKey)
-        // 4. TODO: Validate timestamp, chainId, and hash algorithm
-        throw new NotImplementedException("Stellar Horizon integration not implemented.");
-    }
-
-
-    public Task<string> GetTransactionUrlAsync(AnchorProof anchor, string network = "testnet")
-    {
-        // For dry-run/testnet, return a stubbed URL
-        if (IsDryRun(network))
-        {
-            return Task.FromResult($"https://stellar.explorer/{GetCaip2ChainId(network)}/tx/{anchor.TxHash}");
-        }
-        // TODO: Return real Stellar explorer URL for the transaction
-        throw new NotImplementedException("Stellar explorer integration not implemented.");
-    }
-
-    // Utility: Hash a CodexEntry for anchoring (e.g., SHA-256 over canonicalized JSON)
-    public static byte[] ComputeEntryHash(CodexEntry entry)
-    {
-        // Canonicalize CodexEntry to JSON (RFC 8785 JCS), then hash with SHA-256
-        string canonicalJson;
-        try
-        {
-            canonicalJson = Lockb0x.Core.JsonCanonicalizer.Canonicalize(entry);
-        }
-        catch (NotImplementedException)
-        {
-            throw new NotImplementedException("JsonCanonicalizer is not implemented.");
-        }
-        using var sha256 = System.Security.Cryptography.SHA256.Create();
-        return sha256.ComputeHash(System.Text.Encoding.UTF8.GetBytes(canonicalJson));
-    }
-
-    // Utility: Generate Stellar memo identifier (MD5 hash + public key, max 28 bytes)
-    public static string GenerateStellarMemo(CodexEntry entry, string stellarPublicKey)
-    {
-        // 1. Compute MD5 hash of the canonicalized CodexEntry (16 bytes)
-        byte[] md5Hash = ComputeEntryMd5Hash(entry);
-        
-        // 2. Take first 12 bytes of public key to fit within 28 byte constraint (16 + 12 = 28)
-        byte[] publicKeyBytes = System.Text.Encoding.UTF8.GetBytes(stellarPublicKey);
-        byte[] truncatedPublicKey = new byte[Math.Min(12, publicKeyBytes.Length)];
-        Array.Copy(publicKeyBytes, truncatedPublicKey, truncatedPublicKey.Length);
-        
-        // 3. Combine MD5 hash and truncated public key
-        byte[] combined = new byte[md5Hash.Length + truncatedPublicKey.Length];
-        Array.Copy(md5Hash, 0, combined, 0, md5Hash.Length);
-        Array.Copy(truncatedPublicKey, 0, combined, md5Hash.Length, truncatedPublicKey.Length);
-        
-        // 4. Convert to hex string (ensuring it fits within 28 bytes)
-        string memoHex = BitConverter.ToString(combined).Replace("-", string.Empty).ToLowerInvariant();
-        
-        // Ensure we don't exceed 28 bytes (56 hex characters)
-        if (memoHex.Length > 56)
-        {
-            memoHex = memoHex.Substring(0, 56);
-        }
-        
-        return memoHex;
-    }
-
-    // Utility: Compute MD5 hash of CodexEntry for Stellar memo
-    public static byte[] ComputeEntryMd5Hash(CodexEntry entry)
-    {
-        // Canonicalize CodexEntry to JSON (RFC 8785 JCS), then hash with MD5
-        string canonicalJson;
-        try
-        {
-            canonicalJson = Lockb0x.Core.JsonCanonicalizer.Canonicalize(entry);
-        }
-        catch (NotImplementedException)
-        {
-            throw new NotImplementedException("JsonCanonicalizer is not implemented.");
-        }
-        using var md5 = System.Security.Cryptography.MD5.Create();
-        return md5.ComputeHash(System.Text.Encoding.UTF8.GetBytes(canonicalJson));
-    }
-
-    // Utility: Map network to CAIP-2 chain ID (e.g., "stellar:testnet" or "stellar:pubnet")
-    public static string GetCaip2ChainId(string network)
-    {
-        return network.ToLowerInvariant() switch
-        {
-            "testnet" => "stellar:testnet",
-            "pubnet" => "stellar:pubnet",
-            _ => $"stellar:{network.ToLowerInvariant()}"
-        };
-    }
-
-    // Utility: Dry-run/testnet support (no real transaction submission)
-    public static bool IsDryRun(string network) => network.ToLowerInvariant() == "dry-run" || network.ToLowerInvariant() == "testnet";
+    /// <summary>
+    /// Returns a block explorer URL for the supplied anchor proof.
+    /// </summary>
+    Task<string> GetTransactionUrlAsync(
+        AnchorProof anchor,
+        string network = "testnet",
+        CancellationToken cancellationToken = default);
 }

--- a/Lockb0x.Anchor.Stellar/IStellarHorizonClient.cs
+++ b/Lockb0x.Anchor.Stellar/IStellarHorizonClient.cs
@@ -1,0 +1,16 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Lockb0x.Anchor.Stellar;
+
+/// <summary>
+/// Encapsulates Horizon interactions used by the anchoring service.
+/// </summary>
+public interface IStellarHorizonClient
+{
+    Task<StellarTransactionRecord?> FindTransactionByMemoAsync(StellarMemo memo, StellarNetworkOptions network, CancellationToken cancellationToken);
+
+    Task<StellarTransactionRecord?> GetTransactionAsync(string transactionHash, StellarNetworkOptions network, CancellationToken cancellationToken);
+
+    Task<StellarTransactionRecord> SubmitTransactionAsync(StellarSubmitTransactionRequest request, CancellationToken cancellationToken);
+}

--- a/Lockb0x.Anchor.Stellar/InMemoryStellarHorizonClient.cs
+++ b/Lockb0x.Anchor.Stellar/InMemoryStellarHorizonClient.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Lockb0x.Anchor.Stellar;
+
+/// <summary>
+/// Simple in-memory Horizon client used for tests and dry-run environments.
+/// </summary>
+public sealed class InMemoryStellarHorizonClient : IStellarHorizonClient
+{
+    private readonly ConcurrentDictionary<string, StellarTransactionRecord> _transactions = new();
+    private readonly ConcurrentDictionary<string, string> _memoIndex = new();
+
+    public Task<StellarTransactionRecord?> FindTransactionByMemoAsync(StellarMemo memo, StellarNetworkOptions network, CancellationToken cancellationToken)
+    {
+        var key = BuildMemoKey(network.Name, memo.Fingerprint);
+        if (_memoIndex.TryGetValue(key, out var hash))
+        {
+            return GetTransactionAsync(hash, network, cancellationToken);
+        }
+
+        return Task.FromResult<StellarTransactionRecord?>(null);
+    }
+
+    public Task<StellarTransactionRecord?> GetTransactionAsync(string transactionHash, StellarNetworkOptions network, CancellationToken cancellationToken)
+    {
+        var key = BuildTransactionKey(network.Name, transactionHash);
+        if (_transactions.TryGetValue(key, out var record))
+        {
+            return Task.FromResult<StellarTransactionRecord?>(record);
+        }
+
+        return Task.FromResult<StellarTransactionRecord?>(null);
+    }
+
+    public Task<StellarTransactionRecord> SubmitTransactionAsync(StellarSubmitTransactionRequest request, CancellationToken cancellationToken)
+    {
+        if (request is null)
+        {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var memo = request.Memo ?? throw new ArgumentException("Memo must be provided for Stellar submission.", nameof(request));
+        var network = request.Network ?? throw new ArgumentException("Network configuration is required.", nameof(request));
+
+        var hashBytes = SHA256.HashData(memo.Value.Span);
+        var hash = Convert.ToHexString(hashBytes).ToLowerInvariant();
+        var timestamp = request.RequestedAt ?? DateTimeOffset.UtcNow;
+        var record = new StellarTransactionRecord(hash, memo.Value.ToArray(), memo.MemoType, timestamp, request.PublicKey);
+
+        _transactions[BuildTransactionKey(network.Name, hash)] = record;
+        _memoIndex[BuildMemoKey(network.Name, memo.Fingerprint)] = hash;
+
+        return Task.FromResult(record);
+    }
+
+    private static string BuildMemoKey(string network, string fingerprint) => $"{Normalize(network)}::{fingerprint}";
+
+    private static string BuildTransactionKey(string network, string hash) => $"{Normalize(network)}::{hash}";
+
+    private static string Normalize(string value) => value?.ToLowerInvariant() ?? string.Empty;
+}

--- a/Lockb0x.Anchor.Stellar/Md5AccountMemoStrategy.cs
+++ b/Lockb0x.Anchor.Stellar/Md5AccountMemoStrategy.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using Lockb0x.Core.Canonicalization;
+using Lockb0x.Core.Models;
+
+namespace Lockb0x.Anchor.Stellar;
+
+/// <summary>
+/// Implements the default memo derivation strategy recommended by the Lockb0x specification:
+/// MD5 of the canonical Codex Entry concatenated with the anchoring account identifier, truncated to 28 bytes.
+/// </summary>
+public sealed class Md5AccountMemoStrategy : IMemoStrategy
+{
+    public const int MemoSizeBytes = 28;
+
+    public StellarMemo CreateMemo(CodexEntry entry, string stellarPublicKey, IJsonCanonicalizer canonicalizer)
+    {
+        if (entry is null)
+        {
+            throw new ArgumentNullException(nameof(entry));
+        }
+
+        if (canonicalizer is null)
+        {
+            throw new ArgumentNullException(nameof(canonicalizer));
+        }
+
+        if (string.IsNullOrWhiteSpace(stellarPublicKey))
+        {
+            throw new ArgumentException("Stellar public key must be provided for memo derivation.", nameof(stellarPublicKey));
+        }
+
+        byte[] md5Digest;
+        try
+        {
+            md5Digest = canonicalizer.Hash(entry, HashAlgorithmName.MD5);
+        }
+        catch (Exception ex)
+        {
+            throw new StellarAnchorException("anchor.memo_hash_failed", "Failed to compute MD5 digest for memo derivation.", ex);
+        }
+
+        var publicKeyBytes = Encoding.UTF8.GetBytes(stellarPublicKey.Trim());
+        var memoBytes = new byte[MemoSizeBytes];
+        var copyLength = Math.Min(md5Digest.Length, MemoSizeBytes);
+        Array.Copy(md5Digest, 0, memoBytes, 0, copyLength);
+
+        if (copyLength < MemoSizeBytes)
+        {
+            var remaining = MemoSizeBytes - copyLength;
+            if (publicKeyBytes.Length >= remaining)
+            {
+                Array.Copy(publicKeyBytes, 0, memoBytes, copyLength, remaining);
+            }
+            else
+            {
+                Array.Copy(publicKeyBytes, 0, memoBytes, copyLength, publicKeyBytes.Length);
+                // Pad remaining bytes deterministically using zeros.
+                for (var i = copyLength + publicKeyBytes.Length; i < MemoSizeBytes; i++)
+                {
+                    memoBytes[i] = 0x00;
+                }
+            }
+        }
+
+        var fingerprint = Convert.ToHexString(memoBytes).ToLowerInvariant();
+        var text = Encoding.ASCII.GetString(memoBytes);
+        return new StellarMemo("hash", memoBytes, fingerprint, text);
+    }
+}

--- a/Lockb0x.Anchor.Stellar/StellarAnchorException.cs
+++ b/Lockb0x.Anchor.Stellar/StellarAnchorException.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Lockb0x.Anchor.Stellar;
+
+/// <summary>
+/// Represents failures encountered while anchoring or verifying transactions on Stellar.
+/// </summary>
+public sealed class StellarAnchorException : Exception
+{
+    public StellarAnchorException(string code, string message)
+        : base(message)
+    {
+        Code = code;
+    }
+
+    public StellarAnchorException(string code, string message, Exception innerException)
+        : base(message, innerException)
+    {
+        Code = code;
+    }
+
+    public string Code { get; }
+}

--- a/Lockb0x.Anchor.Stellar/StellarAnchorService.cs
+++ b/Lockb0x.Anchor.Stellar/StellarAnchorService.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using Lockb0x.Core.Canonicalization;
+using Lockb0x.Core.Models;
+
+namespace Lockb0x.Anchor.Stellar;
+
+public sealed class StellarAnchorService : IStellarAnchorService
+{
+    private readonly IJsonCanonicalizer _canonicalizer;
+    private readonly IStellarHorizonClient _horizonClient;
+    private readonly IMemoStrategy _memoStrategy;
+    private readonly StellarAnchorServiceOptions _options;
+    private readonly IClock _clock;
+
+    public StellarAnchorService(
+        IJsonCanonicalizer canonicalizer,
+        IStellarHorizonClient horizonClient,
+        IMemoStrategy? memoStrategy = null,
+        StellarAnchorServiceOptions? options = null,
+        IClock? clock = null)
+    {
+        _canonicalizer = canonicalizer ?? throw new ArgumentNullException(nameof(canonicalizer));
+        _horizonClient = horizonClient ?? throw new ArgumentNullException(nameof(horizonClient));
+        _memoStrategy = memoStrategy ?? new Md5AccountMemoStrategy();
+        _options = options ?? StellarAnchorServiceOptions.CreateDefault();
+        _clock = clock ?? SystemClock.Instance;
+    }
+
+    public async Task<AnchorProof> AnchorAsync(
+        CodexEntry entry,
+        string network = "testnet",
+        string? stellarPublicKey = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (entry is null)
+        {
+            throw new ArgumentNullException(nameof(entry));
+        }
+
+        var networkOptions = ResolveNetwork(network);
+        var account = ResolvePublicKey(stellarPublicKey, networkOptions);
+        var entryHash = ComputeEntryHash(entry);
+        var memo = _memoStrategy.CreateMemo(entry, account, _canonicalizer);
+
+        var existing = await _horizonClient.FindTransactionByMemoAsync(memo, networkOptions, cancellationToken).ConfigureAwait(false);
+        if (existing is not null)
+        {
+            return BuildAnchorProof(existing, networkOptions);
+        }
+
+        string? envelope = null;
+        if (_options.TransactionEnvelopeFactory is not null)
+        {
+            var context = new AnchorTransactionContext(networkOptions, memo, entryHash, account);
+            envelope = await _options.TransactionEnvelopeFactory(context, cancellationToken).ConfigureAwait(false);
+            if (string.IsNullOrWhiteSpace(envelope))
+            {
+                envelope = null;
+            }
+        }
+        else if (networkOptions.RequireSignedEnvelope && !networkOptions.IsDryRun)
+        {
+            throw new StellarAnchorException(
+                "anchor.envelope_required",
+                $"Network '{networkOptions.Name}' requires a signed transaction envelope.");
+        }
+
+        var request = new StellarSubmitTransactionRequest
+        {
+            Network = networkOptions,
+            Memo = memo,
+            EntryHash = entryHash,
+            PublicKey = account,
+            EnvelopeXdr = envelope,
+            RequestedAt = _clock.UtcNow
+        };
+
+        var record = await _horizonClient.SubmitTransactionAsync(request, cancellationToken).ConfigureAwait(false);
+        return BuildAnchorProof(record, networkOptions);
+    }
+
+    public async Task<bool> VerifyAnchorAsync(
+        AnchorProof anchor,
+        CodexEntry entry,
+        string network = "testnet",
+        string? stellarPublicKey = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (anchor is null)
+        {
+            throw new ArgumentNullException(nameof(anchor));
+        }
+
+        if (entry is null)
+        {
+            throw new ArgumentNullException(nameof(entry));
+        }
+
+        var networkOptions = ResolveNetwork(network);
+        if (!string.Equals(anchor.Chain, networkOptions.ChainId, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (!string.Equals(anchor.HashAlgorithm, "sha-256", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var account = ResolvePublicKey(stellarPublicKey, networkOptions);
+        var memo = _memoStrategy.CreateMemo(entry, account, _canonicalizer);
+
+        var record = await _horizonClient.GetTransactionAsync(anchor.TransactionHash, networkOptions, cancellationToken).ConfigureAwait(false);
+        if (record is null)
+        {
+            return false;
+        }
+
+        if (!memo.Matches(record.MemoBytes.Span))
+        {
+            return false;
+        }
+
+        if (anchor.AnchoredAt.HasValue && record.LedgerCloseTime.HasValue)
+        {
+            // Allow for minor clock drift (±5 minutes).
+            var difference = (anchor.AnchoredAt.Value - record.LedgerCloseTime.Value).Duration();
+            if (difference > TimeSpan.FromMinutes(5))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public Task<string> GetTransactionUrlAsync(
+        AnchorProof anchor,
+        string network = "testnet",
+        CancellationToken cancellationToken = default)
+    {
+        if (anchor is null)
+        {
+            throw new ArgumentNullException(nameof(anchor));
+        }
+
+        var networkOptions = ResolveNetwork(network);
+        var url = networkOptions.GetExplorerUrl(anchor.TransactionHash);
+        return Task.FromResult(url);
+    }
+
+    private StellarNetworkOptions ResolveNetwork(string? network)
+    {
+        var key = string.IsNullOrWhiteSpace(network) ? _options.DefaultNetwork : network;
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            throw new StellarAnchorException("anchor.network_missing", "No Stellar network was specified and no default is configured.");
+        }
+
+        if (_options.Networks.TryGetValue(key, out var configured))
+        {
+            return configured;
+        }
+
+        if (_options.AllowUnknownNetworks)
+        {
+            var synthetic = new StellarNetworkOptions
+            {
+                Name = key,
+                ChainId = $"stellar:{key.ToLowerInvariant()}",
+                HorizonEndpoint = new Uri($"https://{key}.stellar.invalid"),
+                IsDryRun = true,
+                RequireSignedEnvelope = false
+            };
+            _options.Networks[key] = synthetic;
+            return synthetic;
+        }
+
+        throw new StellarAnchorException("anchor.network_unknown", $"No Stellar network configuration found for '{key}'.");
+    }
+
+    private static string ResolvePublicKey(string? candidate, StellarNetworkOptions network)
+    {
+        var value = string.IsNullOrWhiteSpace(candidate) ? network.DefaultAccountPublicKey : candidate;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new StellarAnchorException("anchor.public_key_missing", "A Stellar public key must be provided either explicitly or via network configuration.");
+        }
+
+        return value.Trim();
+    }
+
+    private byte[] ComputeEntryHash(CodexEntry entry)
+    {
+        try
+        {
+            return _canonicalizer.Hash(entry, HashAlgorithmName.SHA256);
+        }
+        catch (Exception ex)
+        {
+            throw new StellarAnchorException("anchor.hash_failed", "Failed to compute Codex Entry hash for anchoring.", ex);
+        }
+    }
+
+    private AnchorProof BuildAnchorProof(StellarTransactionRecord record, StellarNetworkOptions network)
+    {
+        return new AnchorProof
+        {
+            Chain = network.ChainId,
+            TransactionHash = record.Hash,
+            HashAlgorithm = "sha-256",
+            AnchoredAt = record.LedgerCloseTime ?? _clock.UtcNow
+        };
+    }
+}

--- a/Lockb0x.Anchor.Stellar/StellarAnchorServiceOptions.cs
+++ b/Lockb0x.Anchor.Stellar/StellarAnchorServiceOptions.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Lockb0x.Anchor.Stellar;
+
+/// <summary>
+/// Configures network behaviour for the Stellar anchoring service.
+/// </summary>
+public sealed class StellarAnchorServiceOptions
+{
+    public StellarAnchorServiceOptions()
+    {
+        Networks = new Dictionary<string, StellarNetworkOptions>(StringComparer.OrdinalIgnoreCase);
+        DefaultNetwork = "testnet";
+    }
+
+    /// <summary>
+    /// Mapping of friendly network names to configuration entries.
+    /// </summary>
+    public IDictionary<string, StellarNetworkOptions> Networks { get; }
+
+    /// <summary>
+    /// The default network used when none is specified.
+    /// </summary>
+    public string DefaultNetwork { get; set; }
+
+    /// <summary>
+    /// When <c>true</c>, unknown networks fall back to a dry-run configuration instead of throwing.
+    /// </summary>
+    public bool AllowUnknownNetworks { get; set; }
+
+    /// <summary>
+    /// Optional factory used to produce signed transaction envelopes for Horizon submission.
+    /// </summary>
+    public Func<AnchorTransactionContext, CancellationToken, Task<string>>? TransactionEnvelopeFactory { get; set; }
+
+    /// <summary>
+    /// Creates a default option set covering Stellar testnet, pubnet, and an explicit dry-run environment.
+    /// </summary>
+    public static StellarAnchorServiceOptions CreateDefault()
+    {
+        var options = new StellarAnchorServiceOptions();
+
+        var testNet = StellarNetworkOptions.CreateTestNet();
+        options.Networks[testNet.Name] = testNet;
+
+        var pubNet = StellarNetworkOptions.CreatePubNet();
+        options.Networks[pubNet.Name] = pubNet;
+        options.Networks["pubnet"] = pubNet;
+        options.Networks["public"] = pubNet;
+        options.Networks["mainnet"] = pubNet;
+
+        var dryRun = StellarNetworkOptions.CreateDryRun();
+        options.Networks[dryRun.Name] = dryRun;
+
+        return options;
+    }
+}

--- a/Lockb0x.Anchor.Stellar/StellarMemo.cs
+++ b/Lockb0x.Anchor.Stellar/StellarMemo.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Linq;
+
+namespace Lockb0x.Anchor.Stellar;
+
+/// <summary>
+/// Represents the memo payload used for Stellar anchoring.
+/// </summary>
+public sealed class StellarMemo
+{
+    public StellarMemo(string memoType, byte[] value, string fingerprint, string? textRepresentation = null)
+    {
+        if (string.IsNullOrWhiteSpace(memoType))
+        {
+            throw new ArgumentException("Memo type must be provided.", nameof(memoType));
+        }
+
+        MemoType = memoType;
+        Value = value ?? throw new ArgumentNullException(nameof(value));
+        Fingerprint = fingerprint ?? throw new ArgumentNullException(nameof(fingerprint));
+        TextRepresentation = textRepresentation;
+    }
+
+    /// <summary>
+    /// Horizon memo type (text, hash, id, return).
+    /// </summary>
+    public string MemoType { get; }
+
+    /// <summary>
+    /// Raw memo bytes (at most 28 bytes for text payloads).
+    /// </summary>
+    public ReadOnlyMemory<byte> Value { get; }
+
+    /// <summary>
+    /// Stable memo fingerprint used for idempotency lookups.
+    /// </summary>
+    public string Fingerprint { get; }
+
+    /// <summary>
+    /// Optional human-readable representation.
+    /// </summary>
+    public string? TextRepresentation { get; }
+
+    /// <summary>
+    /// Encodes the memo bytes as base64 for Horizon queries.
+    /// </summary>
+    public string ToBase64() => Convert.ToBase64String(Value.Span);
+
+    /// <summary>
+    /// Determines whether the supplied memo bytes match the expected payload.
+    /// Accepts Horizon padding behaviour for memo hash payloads.
+    /// </summary>
+    public bool Matches(ReadOnlySpan<byte> other)
+    {
+        var expected = Value.Span;
+        if (expected.Length == other.Length)
+        {
+            return expected.SequenceEqual(other);
+        }
+
+        if (other.Length > expected.Length)
+        {
+            if (!other[..expected.Length].SequenceEqual(expected))
+            {
+                return false;
+            }
+
+            for (var i = expected.Length; i < other.Length; i++)
+            {
+                if (other[i] != 0)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/Lockb0x.Anchor.Stellar/StellarNetworkOptions.cs
+++ b/Lockb0x.Anchor.Stellar/StellarNetworkOptions.cs
@@ -1,0 +1,86 @@
+using System;
+
+namespace Lockb0x.Anchor.Stellar;
+
+/// <summary>
+/// Represents configuration for a Stellar network/environment.
+/// </summary>
+public sealed class StellarNetworkOptions
+{
+    /// <summary>
+    /// Human-readable network name (e.g., "testnet", "pubnet", "dry-run").
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// CAIP-2 compliant chain identifier (e.g., "stellar:testnet").
+    /// </summary>
+    public required string ChainId { get; init; }
+
+    /// <summary>
+    /// Horizon endpoint base URI.
+    /// </summary>
+    public required Uri HorizonEndpoint { get; init; }
+
+    /// <summary>
+    /// Optional public key used when callers do not supply one explicitly.
+    /// </summary>
+    public string? DefaultAccountPublicKey { get; init; }
+
+    /// <summary>
+    /// Indicates whether this network is purely synthetic and should not attempt real Horizon submissions.
+    /// </summary>
+    public bool IsDryRun { get; init; }
+
+    /// <summary>
+    /// When <c>true</c> a signed transaction envelope is required before submission.
+    /// </summary>
+    public bool RequireSignedEnvelope { get; init; }
+
+    /// <summary>
+    /// Template for explorer URLs. Supports {network} and {hash} placeholders.
+    /// </summary>
+    public string ExplorerTransactionUrlTemplate { get; init; } = "https://stellar.expert/explorer/{network}/tx/{hash}";
+
+    public string GetExplorerUrl(string transactionHash)
+    {
+        if (string.IsNullOrWhiteSpace(transactionHash))
+        {
+            throw new ArgumentException("Transaction hash must be provided.", nameof(transactionHash));
+        }
+
+        if (string.IsNullOrWhiteSpace(ExplorerTransactionUrlTemplate))
+        {
+            return new Uri(HorizonEndpoint, $"/transactions/{transactionHash}").ToString();
+        }
+
+        return ExplorerTransactionUrlTemplate
+            .Replace("{network}", Name, StringComparison.OrdinalIgnoreCase)
+            .Replace("{hash}", transactionHash, StringComparison.Ordinal);
+    }
+
+    public static StellarNetworkOptions CreateTestNet() => new()
+    {
+        Name = "testnet",
+        ChainId = "stellar:testnet",
+        HorizonEndpoint = new Uri("https://horizon-testnet.stellar.org"),
+        RequireSignedEnvelope = false
+    };
+
+    public static StellarNetworkOptions CreatePubNet() => new()
+    {
+        Name = "pubnet",
+        ChainId = "stellar:pubnet",
+        HorizonEndpoint = new Uri("https://horizon.stellar.org"),
+        RequireSignedEnvelope = true
+    };
+
+    public static StellarNetworkOptions CreateDryRun() => new()
+    {
+        Name = "dry-run",
+        ChainId = "stellar:dry-run",
+        HorizonEndpoint = new Uri("https://stellar.example/dry-run"),
+        IsDryRun = true,
+        RequireSignedEnvelope = false
+    };
+}

--- a/Lockb0x.Anchor.Stellar/StellarSubmitTransactionRequest.cs
+++ b/Lockb0x.Anchor.Stellar/StellarSubmitTransactionRequest.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace Lockb0x.Anchor.Stellar;
+
+/// <summary>
+/// Represents a Stellar transaction submission request.
+/// </summary>
+public sealed class StellarSubmitTransactionRequest
+{
+    public required StellarNetworkOptions Network { get; init; }
+
+    public required StellarMemo Memo { get; init; }
+
+    public required ReadOnlyMemory<byte> EntryHash { get; init; }
+
+    public required string PublicKey { get; init; }
+
+    /// <summary>
+    /// Optional signed transaction envelope (base64 XDR) ready for Horizon submission.
+    /// </summary>
+    public string? EnvelopeXdr { get; init; }
+
+    /// <summary>
+    /// Optional timestamp when the submission was requested.
+    /// </summary>
+    public DateTimeOffset? RequestedAt { get; init; }
+}

--- a/Lockb0x.Anchor.Stellar/StellarTransactionRecord.cs
+++ b/Lockb0x.Anchor.Stellar/StellarTransactionRecord.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Security.Cryptography;
+
+namespace Lockb0x.Anchor.Stellar;
+
+/// <summary>
+/// Represents a Stellar transaction relevant for anchoring.
+/// </summary>
+public sealed class StellarTransactionRecord
+{
+    public StellarTransactionRecord(string hash, byte[] memoBytes, string memoType, DateTimeOffset? ledgerCloseTime, string? sourceAccount = null)
+    {
+        if (string.IsNullOrWhiteSpace(hash))
+        {
+            throw new ArgumentException("Transaction hash must be provided.", nameof(hash));
+        }
+
+        Hash = hash;
+        MemoBytes = memoBytes ?? Array.Empty<byte>();
+        MemoType = memoType ?? "hash";
+        LedgerCloseTime = ledgerCloseTime;
+        SourceAccount = sourceAccount;
+    }
+
+    public string Hash { get; }
+
+    public ReadOnlyMemory<byte> MemoBytes { get; }
+
+    public string MemoType { get; }
+
+    public DateTimeOffset? LedgerCloseTime { get; }
+
+    public string? SourceAccount { get; }
+
+    public static StellarTransactionRecord CreateSynthetic(StellarMemo memo, StellarNetworkOptions network, DateTimeOffset timestamp)
+    {
+        var hashBytes = SHA256.HashData(memo.Value.Span);
+        var hash = Convert.ToHexString(hashBytes).ToLowerInvariant();
+        return new StellarTransactionRecord(hash, memo.Value.ToArray(), memo.MemoType, timestamp, network.DefaultAccountPublicKey);
+    }
+}

--- a/Lockb0x.Anchor.Stellar/SystemClock.cs
+++ b/Lockb0x.Anchor.Stellar/SystemClock.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Lockb0x.Anchor.Stellar;
+
+public sealed class SystemClock : IClock
+{
+    public static SystemClock Instance { get; } = new();
+
+    private SystemClock()
+    {
+    }
+
+    public DateTimeOffset UtcNow => DateTimeOffset.UtcNow;
+}

--- a/Lockb0x.Tests/Lockb0x.Tests.csproj
+++ b/Lockb0x.Tests/Lockb0x.Tests.csproj
@@ -7,6 +7,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
     <ItemGroup>
+  <ProjectReference Include="..\Lockb0x.Anchor.Stellar\Lockb0x.Anchor.Stellar.csproj" />
   <ProjectReference Include="..\Lockb0x.Core\Lockb0x.Core.csproj" />
   <ProjectReference Include="..\Lockb0x.Signing\Lockb0x.Signing.csproj" />
     </ItemGroup>

--- a/Lockb0x.Tests/StellarAnchorServiceTests.cs
+++ b/Lockb0x.Tests/StellarAnchorServiceTests.cs
@@ -1,1 +1,115 @@
-// File removed: not implemented in current state.
+using System;
+using System.Threading.Tasks;
+using Lockb0x.Anchor.Stellar;
+using Lockb0x.Core.Canonicalization;
+using Lockb0x.Core.Models;
+
+namespace Lockb0x.Tests;
+
+public class StellarAnchorServiceTests
+{
+    private const string DefaultPublicKey = "GCFXTESTACCOUNT000000000000000000000000000000000000000000000";
+
+    [Fact]
+    public async Task AnchorAsync_ReturnsAnchorProof_WithChainAndHash()
+    {
+        var service = CreateService(out var entry);
+        var proof = await service.AnchorAsync(entry, "testnet", DefaultPublicKey);
+
+        Assert.Equal("stellar:testnet", proof.Chain);
+        Assert.Equal("sha-256", proof.HashAlgorithm);
+        Assert.False(string.IsNullOrWhiteSpace(proof.TransactionHash));
+        Assert.True(proof.AnchoredAt.HasValue);
+    }
+
+    [Fact]
+    public async Task AnchorAsync_IsIdempotent_ForSameEntry()
+    {
+        var service = CreateService(out var entry);
+        var first = await service.AnchorAsync(entry, "testnet", DefaultPublicKey);
+        var second = await service.AnchorAsync(entry, "testnet", DefaultPublicKey);
+
+        Assert.Equal(first.TransactionHash, second.TransactionHash);
+    }
+
+    [Fact]
+    public async Task VerifyAnchorAsync_ReturnsTrue_WhenMemoMatches()
+    {
+        var service = CreateService(out var entry);
+        var anchor = await service.AnchorAsync(entry, "testnet", DefaultPublicKey);
+
+        var verified = await service.VerifyAnchorAsync(anchor, entry, "testnet", DefaultPublicKey);
+        Assert.True(verified);
+    }
+
+    [Fact]
+    public async Task VerifyAnchorAsync_ReturnsFalse_WhenEntryTampered()
+    {
+        var service = CreateService(out var entry);
+        var anchor = await service.AnchorAsync(entry, "testnet", DefaultPublicKey);
+
+        var tampered = CreateEntry(artifact: "TamperedArtifact");
+        var verified = await service.VerifyAnchorAsync(anchor, tampered, "testnet", DefaultPublicKey);
+
+        Assert.False(verified);
+    }
+
+    [Fact]
+    public async Task GetTransactionUrlAsync_UsesExplorerTemplate()
+    {
+        var service = CreateService(out var entry);
+        var anchor = await service.AnchorAsync(entry, "testnet", DefaultPublicKey);
+
+        var url = await service.GetTransactionUrlAsync(anchor, "testnet");
+        Assert.Contains(anchor.TransactionHash, url);
+        Assert.Contains("stellar.expert", url);
+    }
+
+    private static StellarAnchorService CreateService(out CodexEntry entry)
+    {
+        var canonicalizer = new JcsCanonicalizer();
+        var horizonClient = new InMemoryStellarHorizonClient();
+        var options = StellarAnchorServiceOptions.CreateDefault();
+        options.Networks["testnet"].DefaultAccountPublicKey = DefaultPublicKey;
+
+        var service = new StellarAnchorService(canonicalizer, horizonClient, options: options);
+        entry = CreateEntry();
+        return service;
+    }
+
+    private static CodexEntry CreateEntry(string artifact = "SampleArtifact")
+    {
+        return new CodexEntryBuilder()
+            .WithId(Guid.NewGuid())
+            .WithVersion("1.0")
+            .WithStorage(new StorageDescriptor
+            {
+                Protocol = "ipfs",
+                IntegrityProof = "ni:///sha-256;abcdef",
+                MediaType = "application/json",
+                SizeBytes = 1234,
+                Location = new StorageLocation
+                {
+                    Provider = "IPFS",
+                    Region = "us-east",
+                    Jurisdiction = "US"
+                }
+            })
+            .WithIdentity(new IdentityDescriptor
+            {
+                Org = "did:example:org",
+                Process = "unit-test",
+                Artifact = artifact
+            })
+            .WithTimestamp(DateTimeOffset.UtcNow)
+            .WithAnchor(new AnchorProof
+            {
+                Chain = "stellar:testnet",
+                TransactionHash = "placeholder",
+                HashAlgorithm = "sha-256",
+                AnchoredAt = DateTimeOffset.UtcNow
+            })
+            .WithSignatures(Array.Empty<SignatureProof>())
+            .Build();
+    }
+}


### PR DESCRIPTION
## Summary
- implement the Stellar anchoring service with configurable memo strategy, network options, and transaction submission pipeline
- add Horizon client abstractions including HTTP and in-memory implementations plus supporting models and utilities
- introduce unit tests covering anchoring idempotency, verification, and transaction URL generation

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68dedadf956c832db19311500337cb8b