### PR TITLE
Implement IPFS storage adapter

### DIFF
--- a/Lockb0x.Storage/Adapters/IpfsStorageAdapter.cs
+++ b/Lockb0x.Storage/Adapters/IpfsStorageAdapter.cs
@@ -1,0 +1,464 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Lockb0x.Core.Models;
+using Lockb0x.Core.Utilities;
+using Lockb0x.Storage.Internal;
+
+namespace Lockb0x.Storage.Adapters;
+
+/// <summary>
+/// Storage adapter that integrates with an IPFS node via the HTTP API.
+/// </summary>
+public sealed class IpfsStorageAdapter : IStorageAdapter, IAsyncDisposable
+{
+    private readonly HttpClient _apiClient;
+    private readonly HttpClient? _gatewayClient;
+    private readonly bool _disposeApiClient;
+    private readonly bool _disposeGatewayClient;
+    private readonly IpfsStorageOptions _options;
+
+    public IpfsStorageAdapter(IpfsStorageOptions options)
+        : this(options, apiClient: null, gatewayClient: null)
+    {
+    }
+
+    public IpfsStorageAdapter(IpfsStorageOptions options, HttpClient? apiClient, HttpClient? gatewayClient)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        if (options.ApiEndpoint is null)
+        {
+            throw new ArgumentException("An IPFS API endpoint must be supplied.", nameof(options));
+        }
+
+        if (string.IsNullOrWhiteSpace(options.Region))
+        {
+            throw new ArgumentException("Region must be provided for IPFS storage metadata.", nameof(options));
+        }
+
+        if (string.IsNullOrWhiteSpace(options.Jurisdiction))
+        {
+            throw new ArgumentException("Jurisdiction must be provided for IPFS storage metadata.", nameof(options));
+        }
+
+        if (string.IsNullOrWhiteSpace(options.Provider))
+        {
+            throw new ArgumentException("Provider must be provided for IPFS storage metadata.", nameof(options));
+        }
+
+        _apiClient = apiClient ?? CreateHttpClient(NormalizeBaseAddress(options.ApiEndpoint));
+        _disposeApiClient = apiClient is null;
+
+        if (gatewayClient is not null)
+        {
+            _gatewayClient = gatewayClient;
+        }
+        else if (options.GatewayEndpoint is not null)
+        {
+            _gatewayClient = CreateHttpClient(NormalizeBaseAddress(options.GatewayEndpoint));
+            _disposeGatewayClient = true;
+        }
+    }
+
+    public async Task<StorageResult> StoreAsync(StorageUploadRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var (cid, size, digest, nativeMetadata) = await AddToIpfsAsync(request, cancellationToken).ConfigureAwait(false);
+        var cidInfo = CidUtility.Parse(cid);
+        if (cidInfo.UsesSha256)
+        {
+            if (!digest.AsSpan().SequenceEqual(cidInfo.Digest))
+            {
+                throw new StorageAdapterException("CID digest mismatch detected after IPFS upload.");
+            }
+        }
+
+        var integrityDigest = cidInfo.UsesSha256 ? cidInfo.Digest : digest;
+        var descriptor = new StorageDescriptor
+        {
+            Protocol = "ipfs",
+            IntegrityProof = NiUri.Create(integrityDigest, "sha-256"),
+            MediaType = request.MediaType,
+            SizeBytes = size,
+            Location = BuildLocation()
+        };
+
+        var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["Name"] = nativeMetadata.Name,
+            ["Pin"] = _options.PinByDefault ? "true" : "false",
+            ["CidVersion"] = cidInfo.Version.ToString(CultureInfo.InvariantCulture)
+        };
+        if (!string.IsNullOrEmpty(nativeMetadata.SizeFromApi))
+        {
+            metadata["ReportedSize"] = nativeMetadata.SizeFromApi!;
+        }
+
+        return new StorageResult
+        {
+            Descriptor = descriptor,
+            ContentIdentifier = cid,
+            ResourceUri = BuildResourceUri(cid),
+            NativeMetadata = metadata
+        };
+    }
+
+    public async Task<Stream> FetchAsync(string location, CancellationToken cancellationToken = default)
+    {
+        var cid = NormalizeLocation(location);
+        return await FetchContentStreamInternalAsync(cid, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<bool> ExistsAsync(string location, CancellationToken cancellationToken = default)
+    {
+        var cid = NormalizeLocation(location);
+        try
+        {
+            if (_gatewayClient is not null)
+            {
+                using var headRequest = new HttpRequestMessage(HttpMethod.Head, $"ipfs/{cid}");
+                using var headResponse = await _gatewayClient.SendAsync(headRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                if (headResponse.StatusCode == HttpStatusCode.NotFound)
+                {
+                    return false;
+                }
+
+                if (headResponse.StatusCode == HttpStatusCode.MethodNotAllowed)
+                {
+                    using var rangeRequest = new HttpRequestMessage(HttpMethod.Get, $"ipfs/{cid}");
+                    rangeRequest.Headers.Range = new RangeHeaderValue(0, 0);
+                    using var rangeResponse = await _gatewayClient.SendAsync(rangeRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    if (rangeResponse.StatusCode == HttpStatusCode.NotFound)
+                    {
+                        return false;
+                    }
+
+                    return rangeResponse.IsSuccessStatusCode;
+                }
+
+                return headResponse.IsSuccessStatusCode;
+            }
+
+            using var response = await _apiClient.PostAsync($"api/v0/block/stat?arg={Uri.EscapeDataString(cid)}", null, cancellationToken).ConfigureAwait(false);
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                return false;
+            }
+
+            return response.IsSuccessStatusCode;
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new StorageAdapterException("IPFS availability check failed due to a network error.", ex);
+        }
+    }
+
+    public async Task<StorageResult> GetMetadataAsync(string location, CancellationToken cancellationToken = default)
+    {
+        var cid = NormalizeLocation(location);
+        var cidInfo = CidUtility.Parse(cid);
+
+        long size = 0;
+        string? mediaType = null;
+        if (_gatewayClient is not null)
+        {
+            using var headRequest = new HttpRequestMessage(HttpMethod.Head, $"ipfs/{cid}");
+            using var headResponse = await _gatewayClient.SendAsync(headRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            if (headResponse.StatusCode == HttpStatusCode.NotFound)
+            {
+                throw new StorageAdapterException($"IPFS content '{cid}' was not found at the configured gateway.");
+            }
+
+            if (headResponse.IsSuccessStatusCode)
+            {
+                if (headResponse.Content.Headers.ContentLength is long contentLength)
+                {
+                    size = contentLength;
+                }
+
+                if (headResponse.Content.Headers.ContentType is { } contentType)
+                {
+                    mediaType = contentType.ToString();
+                }
+            }
+        }
+
+        if (size == 0)
+        {
+            using var statResponse = await _apiClient.PostAsync($"api/v0/block/stat?arg={Uri.EscapeDataString(cid)}", null, cancellationToken).ConfigureAwait(false);
+            if (statResponse.StatusCode == HttpStatusCode.NotFound)
+            {
+                throw new StorageAdapterException($"IPFS content '{cid}' was not found.");
+            }
+
+            statResponse.EnsureSuccessStatusCode();
+            using var statDoc = await JsonDocument.ParseAsync(await statResponse.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false), cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (statDoc.RootElement.TryGetProperty("Size", out var sizeElement) && sizeElement.ValueKind == JsonValueKind.Number)
+            {
+                size = sizeElement.GetInt64();
+            }
+            else if (statDoc.RootElement.TryGetProperty("CumulativeSize", out var cumulative) && cumulative.ValueKind == JsonValueKind.Number)
+            {
+                size = cumulative.GetInt64();
+            }
+        }
+
+        byte[] integrityDigest;
+        if (cidInfo.UsesSha256)
+        {
+            integrityDigest = cidInfo.Digest;
+        }
+        else
+        {
+            var download = await DownloadAndHashAsync(cid, cancellationToken).ConfigureAwait(false);
+            integrityDigest = download.Digest;
+            if (download.Size > 0)
+            {
+                size = download.Size;
+            }
+            mediaType ??= "application/octet-stream";
+        }
+
+        mediaType ??= "application/octet-stream";
+
+        var descriptor = new StorageDescriptor
+        {
+            Protocol = "ipfs",
+            IntegrityProof = NiUri.Create(integrityDigest, "sha-256"),
+            MediaType = mediaType,
+            SizeBytes = size,
+            Location = BuildLocation()
+        };
+
+        var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["CidVersion"] = cidInfo.Version.ToString(CultureInfo.InvariantCulture),
+            ["Codec"] = cidInfo.Codec.ToString(CultureInfo.InvariantCulture)
+        };
+
+        return new StorageResult
+        {
+            Descriptor = descriptor,
+            ContentIdentifier = cid,
+            ResourceUri = BuildResourceUri(cid),
+            NativeMetadata = metadata
+        };
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        if (_disposeApiClient)
+        {
+            _apiClient.Dispose();
+        }
+
+        if (_disposeGatewayClient && _gatewayClient is not null)
+        {
+            _gatewayClient.Dispose();
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    private async Task<(string Cid, long Size, byte[] Digest, (string Name, string? SizeFromApi) NativeMetadata)> AddToIpfsAsync(StorageUploadRequest request, CancellationToken cancellationToken)
+    {
+        using var hashingStream = new HashingStream(request.Content, leaveOpen: true);
+        using var streamContent = new StreamContent(hashingStream);
+        streamContent.Headers.ContentType = MediaTypeHeaderValue.Parse(request.MediaType);
+        if (request.ContentLength.HasValue)
+        {
+            streamContent.Headers.ContentLength = request.ContentLength.Value;
+        }
+
+        using var form = new MultipartFormDataContent
+        {
+            { streamContent, "file", request.FileName }
+        };
+
+        var endpoint = new StringBuilder("api/v0/add?")
+            .Append("pin=").Append(_options.PinByDefault ? "true" : "false")
+            .Append("&cid-version=").Append(_options.CidVersion.ToString(CultureInfo.InvariantCulture))
+            .Append("&hash=sha2-256")
+            .Append("&raw-leaves=").Append(_options.UseRawLeaves ? "true" : "false")
+            .Append("&wrap-with-directory=false")
+            .Append("&progress=false")
+            .ToString();
+
+        using var response = await _apiClient.PostAsync(endpoint, form, cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        var addResult = await ParseAddResponseAsync(response.Content, cancellationToken).ConfigureAwait(false);
+        var digest = hashingStream.GetHashAndReset();
+        var size = request.ContentLength ?? hashingStream.BytesProcessed;
+        return (addResult.Hash, size, digest, (Name: addResult.Name, SizeFromApi: addResult.Size));
+    }
+
+    private static async Task<IpfsAddResponse> ParseAddResponseAsync(HttpContent content, CancellationToken cancellationToken)
+    {
+        await using var responseStream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        using var reader = new StreamReader(responseStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true);
+        string? line = null;
+        while (!reader.EndOfStream)
+        {
+            var current = await reader.ReadLineAsync().ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(current))
+            {
+                line = current;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(line))
+        {
+            throw new StorageAdapterException("Unexpected empty response from IPFS add operation.");
+        }
+
+        using var document = JsonDocument.Parse(line);
+        var root = document.RootElement;
+        var hash = root.GetProperty("Hash").GetString();
+        if (string.IsNullOrWhiteSpace(hash))
+        {
+            throw new StorageAdapterException("IPFS add response did not include a CID.");
+        }
+
+        var size = root.TryGetProperty("Size", out var sizeElement) ? sizeElement.GetString() : null;
+        var name = root.TryGetProperty("Name", out var nameElement) ? nameElement.GetString() ?? string.Empty : string.Empty;
+        return new IpfsAddResponse(name, hash, size);
+    }
+
+    private StorageLocation BuildLocation() => new()
+    {
+        Region = _options.Region,
+        Jurisdiction = _options.Jurisdiction,
+        Provider = _options.Provider
+    };
+
+    private static Uri NormalizeBaseAddress(Uri uri)
+    {
+        if (!uri.OriginalString.EndsWith('/', StringComparison.Ordinal))
+        {
+            return new Uri(uri.OriginalString + '/', UriKind.Absolute);
+        }
+
+        return uri;
+    }
+
+    private static HttpClient CreateHttpClient(Uri baseAddress)
+    {
+        var client = new HttpClient
+        {
+            BaseAddress = baseAddress
+        };
+        return client;
+    }
+
+    private static string NormalizeLocation(string location)
+    {
+        if (string.IsNullOrWhiteSpace(location))
+        {
+            throw new ArgumentException("Location cannot be null or empty.", nameof(location));
+        }
+
+        var trimmed = location.Trim();
+        if (trimmed.StartsWith("ipfs://", StringComparison.OrdinalIgnoreCase))
+        {
+            trimmed = trimmed[7..];
+        }
+
+        if (trimmed.StartsWith("/ipfs/", StringComparison.OrdinalIgnoreCase))
+        {
+            trimmed = trimmed[6..];
+        }
+
+        var slashIndex = trimmed.IndexOf('/', StringComparison.Ordinal);
+        if (slashIndex > 0)
+        {
+            trimmed = trimmed[..slashIndex];
+        }
+
+        return trimmed;
+    }
+
+    private string BuildResourceUri(string cid)
+        => _gatewayClient is not null
+            ? new Uri(_gatewayClient.BaseAddress!, $"ipfs/{cid}").ToString()
+            : $"ipfs://{cid}";
+
+    private async Task<(byte[] Digest, long Size)> DownloadAndHashAsync(string cid, CancellationToken cancellationToken)
+    {
+        await using var responseStream = await FetchContentStreamInternalAsync(cid, cancellationToken).ConfigureAwait(false);
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        var buffer = ArrayPool<byte>.Shared.Rent(81920);
+        long total = 0;
+        try
+        {
+            int read;
+            while ((read = await responseStream.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken).ConfigureAwait(false)) > 0)
+            {
+                hash.AppendData(buffer.AsSpan(0, read));
+                total += read;
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+
+        return (Digest: hash.GetHashAndReset(), Size: total);
+    }
+
+    private async Task<HttpResponseStream> FetchContentStreamInternalAsync(string cid, CancellationToken cancellationToken)
+    {
+        if (_gatewayClient is not null)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, $"ipfs/{cid}");
+            var response = await _gatewayClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                response.Dispose();
+                throw new StorageAdapterException($"IPFS content '{cid}' was not found at the configured gateway.");
+            }
+
+            response.EnsureSuccessStatusCode();
+            var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            return new HttpResponseStream(stream, response);
+        }
+        else
+        {
+            var response = await _apiClient.PostAsync($"api/v0/cat?arg={Uri.EscapeDataString(cid)}", null, cancellationToken).ConfigureAwait(false);
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                response.Dispose();
+                throw new StorageAdapterException($"IPFS content '{cid}' was not found.");
+            }
+
+            response.EnsureSuccessStatusCode();
+            var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            return new HttpResponseStream(stream, response);
+        }
+    }
+
+    private readonly struct IpfsAddResponse
+    {
+        public IpfsAddResponse(string name, string hash, string? size)
+        {
+            Name = name;
+            Hash = hash;
+            Size = size;
+        }
+
+        public string Name { get; }
+        public string Hash { get; }
+        public string? Size { get; }
+    }
+}

--- a/Lockb0x.Storage/Class1.cs
+++ b/Lockb0x.Storage/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace Lockb0x.Storage;
-
-public class Class1
-{
-
-}

--- a/Lockb0x.Storage/IStorageAdapter.cs
+++ b/Lockb0x.Storage/IStorageAdapter.cs
@@ -1,48 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
-using Lockb0x.Core;
+using Lockb0x.Core.Models;
 
 namespace Lockb0x.Storage;
 
+/// <summary>
+/// Contract implemented by storage backends for the Lockb0x protocol.
+/// </summary>
 public interface IStorageAdapter
 {
-    Task<StorageProof> StoreAsync(byte[] data, string fileName);
-    Task<byte[]> FetchAsync(string location);
-    Task<bool> ExistsAsync(string location);
-    Task<StorageProof> GetMetadataAsync(string location);
+    /// <summary>
+    /// Stores the supplied payload in the backing store and returns a populated storage descriptor.
+    /// </summary>
+    Task<StorageResult> StoreAsync(StorageUploadRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the payload identified by <paramref name="location"/> as a read-only stream.
+    /// </summary>
+    Task<Stream> FetchAsync(string location, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Determines whether the supplied location currently resolves to content in the backing store.
+    /// </summary>
+    Task<bool> ExistsAsync(string location, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Resolves descriptive metadata for the supplied location.
+    /// </summary>
+    Task<StorageResult> GetMetadataAsync(string location, CancellationToken cancellationToken = default);
 }
 
-// IPFS Adapter stub
-public class IpfsStorageAdapter : IStorageAdapter
+/// <summary>
+/// Represents the request payload for storing content in an adapter.
+/// </summary>
+public sealed class StorageUploadRequest
 {
-    public Task<StorageProof> StoreAsync(byte[] data, string fileName) => throw new System.NotImplementedException();
-    public Task<byte[]> FetchAsync(string location) => throw new System.NotImplementedException();
-    public Task<bool> ExistsAsync(string location) => throw new System.NotImplementedException();
-    public Task<StorageProof> GetMetadataAsync(string location) => throw new System.NotImplementedException();
+    public StorageUploadRequest(Stream content, string fileName, string mediaType)
+    {
+        Content = content ?? throw new ArgumentNullException(nameof(content));
+        if (!content.CanRead)
+        {
+            throw new ArgumentException("The provided content stream must be readable.", nameof(content));
+        }
+
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            throw new ArgumentException("A non-empty file name is required.", nameof(fileName));
+        }
+
+        if (string.IsNullOrWhiteSpace(mediaType))
+        {
+            throw new ArgumentException("A non-empty media type is required.", nameof(mediaType));
+        }
+
+        FileName = fileName;
+        MediaType = mediaType;
+    }
+
+    /// <summary>
+    /// The payload stream to upload.
+    /// </summary>
+    public Stream Content { get; }
+
+    /// <summary>
+    /// Logical name of the file being uploaded.
+    /// </summary>
+    public string FileName { get; }
+
+    /// <summary>
+    /// MIME media type for the payload.
+    /// </summary>
+    public string MediaType { get; }
+
+    /// <summary>
+    /// Optionally supplies a known byte length to optimise upload metadata.
+    /// </summary>
+    public long? ContentLength { get; init; }
 }
 
-// S3 Adapter stub
+/// <summary>
+/// Represents the canonical result returned by storage adapters.
+/// </summary>
+public sealed record StorageResult
+{
+    public required StorageDescriptor Descriptor { get; init; }
+
+    /// <summary>
+    /// The native identifier supplied by the backend (e.g., CID for IPFS).
+    /// </summary>
+    public required string ContentIdentifier { get; init; }
+
+    /// <summary>
+    /// Canonical resource URI that can be dereferenced for audits.
+    /// </summary>
+    public required string ResourceUri { get; init; }
+
+    /// <summary>
+    /// Optional backend-specific metadata returned alongside the descriptor.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? NativeMetadata { get; init; }
+}
+
+/// <summary>
+/// Error raised when a storage adapter encounters an unrecoverable condition.
+/// </summary>
+public sealed class StorageAdapterException : Exception
+{
+    public StorageAdapterException(string message)
+        : base(message)
+    {
+    }
+
+    public StorageAdapterException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}
+
 public class S3StorageAdapter : IStorageAdapter
 {
-    public Task<StorageProof> StoreAsync(byte[] data, string fileName) => throw new System.NotImplementedException();
-    public Task<byte[]> FetchAsync(string location) => throw new System.NotImplementedException();
-    public Task<bool> ExistsAsync(string location) => throw new System.NotImplementedException();
-    public Task<StorageProof> GetMetadataAsync(string location) => throw new System.NotImplementedException();
+    public Task<StorageResult> StoreAsync(StorageUploadRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+    public Task<Stream> FetchAsync(string location, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+    public Task<bool> ExistsAsync(string location, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+    public Task<StorageResult> GetMetadataAsync(string location, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 }
 
-// GCS Adapter stub
 public class GcsStorageAdapter : IStorageAdapter
 {
-    public Task<StorageProof> StoreAsync(byte[] data, string fileName) => throw new System.NotImplementedException();
-    public Task<byte[]> FetchAsync(string location) => throw new System.NotImplementedException();
-    public Task<bool> ExistsAsync(string location) => throw new System.NotImplementedException();
-    public Task<StorageProof> GetMetadataAsync(string location) => throw new System.NotImplementedException();
+    public Task<StorageResult> StoreAsync(StorageUploadRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+    public Task<Stream> FetchAsync(string location, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+    public Task<bool> ExistsAsync(string location, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+    public Task<StorageResult> GetMetadataAsync(string location, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 }
 
-// Mock/Local Adapter stub
 public class LocalStorageAdapter : IStorageAdapter
 {
-    public Task<StorageProof> StoreAsync(byte[] data, string fileName) => throw new System.NotImplementedException();
-    public Task<byte[]> FetchAsync(string location) => throw new System.NotImplementedException();
-    public Task<bool> ExistsAsync(string location) => throw new System.NotImplementedException();
-    public Task<StorageProof> GetMetadataAsync(string location) => throw new System.NotImplementedException();
+    public Task<StorageResult> StoreAsync(StorageUploadRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+    public Task<Stream> FetchAsync(string location, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+    public Task<bool> ExistsAsync(string location, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+    public Task<StorageResult> GetMetadataAsync(string location, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 }

--- a/Lockb0x.Storage/Internal/CidUtility.cs
+++ b/Lockb0x.Storage/Internal/CidUtility.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Numerics;
+
+namespace Lockb0x.Storage.Internal;
+
+internal static class CidUtility
+{
+    private const string Base32Alphabet = "abcdefghijklmnopqrstuvwxyz234567";
+
+    public const int Sha2_256Code = 0x12;
+    private const int DagPbCodec = 0x70;
+
+    public static CidInfo Parse(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException("CID value cannot be null or empty.", nameof(value));
+        }
+
+        var trimmed = value.Trim();
+        if (trimmed.StartsWith("ipfs://", StringComparison.OrdinalIgnoreCase))
+        {
+            trimmed = trimmed[7..];
+        }
+
+        if (trimmed.StartsWith("/ipfs/", StringComparison.OrdinalIgnoreCase))
+        {
+            trimmed = trimmed[6..];
+        }
+
+        var slashIndex = trimmed.IndexOf('/', StringComparison.Ordinal);
+        if (slashIndex > 0)
+        {
+            trimmed = trimmed[..slashIndex];
+        }
+
+        byte[] raw;
+        int version;
+        int codec;
+        ReadOnlySpan<byte> multihashBytes;
+
+        if (trimmed.StartsWith("Qm", StringComparison.Ordinal))
+        {
+            raw = Base58Decode(trimmed);
+            version = 0;
+            codec = DagPbCodec;
+            multihashBytes = raw;
+        }
+        else
+        {
+            raw = DecodeMultibase(trimmed, out _);
+            var offset = 0;
+            version = (int)ReadVarint(raw, ref offset);
+            codec = (int)ReadVarint(raw, ref offset);
+            multihashBytes = raw[offset..];
+        }
+
+        var (hashCode, digest) = ParseMultihash(multihashBytes);
+        return new CidInfo(version, codec, hashCode, digest);
+    }
+
+    private static (int HashCode, byte[] Digest) ParseMultihash(ReadOnlySpan<byte> multihash)
+    {
+        if (multihash.IsEmpty)
+        {
+            throw new FormatException("Multihash payload is empty.");
+        }
+
+        var offset = 0;
+        var code = (int)ReadVarint(multihash, ref offset);
+        var length = (int)ReadVarint(multihash, ref offset);
+        if (length < 0 || offset + length > multihash.Length)
+        {
+            throw new FormatException("Multihash length is invalid.");
+        }
+
+        var digest = multihash.Slice(offset, length).ToArray();
+        return (code, digest);
+    }
+
+    private static byte[] DecodeMultibase(string value, out char prefix)
+    {
+        if (value.Length < 2)
+        {
+            throw new FormatException("CID is too short to contain multibase payload.");
+        }
+
+        prefix = value[0];
+        var payload = value[1..];
+        return prefix switch
+        {
+            'b' or 'B' => Base32Decode(payload),
+            'z' or 'Z' => Base58Decode(payload),
+            'f' or 'F' => Convert.FromHexString(payload),
+            _ => throw new FormatException(string.Create(CultureInfo.InvariantCulture, $"Unsupported multibase prefix '{prefix}'."))
+        };
+    }
+
+    private static byte[] Base32Decode(string value)
+    {
+        if (value.Length == 0)
+        {
+            return Array.Empty<byte>();
+        }
+
+        var sanitized = value.Replace("=", string.Empty, StringComparison.Ordinal).ToLowerInvariant();
+        var buffer = 0;
+        var bits = 0;
+        var output = new List<byte>(sanitized.Length * 5 / 8);
+
+        foreach (var c in sanitized)
+        {
+            var index = Base32Alphabet.IndexOf(c);
+            if (index < 0)
+            {
+                throw new FormatException(string.Create(CultureInfo.InvariantCulture, $"Invalid base32 character '{c}'."));
+            }
+
+            buffer = (buffer << 5) | index;
+            bits += 5;
+            if (bits >= 8)
+            {
+                bits -= 8;
+                output.Add((byte)((buffer >> bits) & 0xFF));
+            }
+        }
+
+        if (bits > 0 && (buffer & ((1 << bits) - 1)) != 0)
+        {
+            throw new FormatException("Non-zero padding bits encountered in base32 payload.");
+        }
+
+        return output.ToArray();
+    }
+
+    private static byte[] Base58Decode(string value)
+    {
+        const string alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+        if (value.Length == 0)
+        {
+            return Array.Empty<byte>();
+        }
+
+        var result = BigInteger.Zero;
+        foreach (var c in value)
+        {
+            var index = alphabet.IndexOf(c);
+            if (index < 0)
+            {
+                throw new FormatException(string.Create(CultureInfo.InvariantCulture, $"Invalid base58 character '{c}'."));
+            }
+
+            result = result * 58 + index;
+        }
+
+        var bytes = result.ToByteArray(isUnsigned: true, isBigEndian: true);
+        var leadingZeroCount = 0;
+        foreach (var c in value)
+        {
+            if (c == '1')
+            {
+                leadingZeroCount++;
+                continue;
+            }
+            break;
+        }
+
+        if (leadingZeroCount > 0)
+        {
+            var extended = new byte[leadingZeroCount + bytes.Length];
+            Array.Copy(bytes, 0, extended, leadingZeroCount, bytes.Length);
+            bytes = extended;
+        }
+
+        return bytes;
+    }
+
+    private static ulong ReadVarint(ReadOnlySpan<byte> data, ref int offset)
+    {
+        ulong result = 0;
+        var shift = 0;
+        while (offset < data.Length)
+        {
+            var b = data[offset++];
+            result |= (ulong)(b & 0x7F) << shift;
+            if ((b & 0x80) == 0)
+            {
+                return result;
+            }
+
+            shift += 7;
+            if (shift > 63)
+            {
+                throw new FormatException("Varint exceeds 64-bit range.");
+            }
+        }
+
+        throw new FormatException("Unexpected end of buffer while decoding varint.");
+    }
+}
+
+internal readonly record struct CidInfo(int Version, int Codec, int HashAlgorithmCode, byte[] Digest)
+{
+    public bool UsesSha256 => HashAlgorithmCode == CidUtility.Sha2_256Code && Digest.Length == 32;
+}

--- a/Lockb0x.Storage/Internal/HashingStream.cs
+++ b/Lockb0x.Storage/Internal/HashingStream.cs
@@ -1,0 +1,151 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Lockb0x.Storage.Internal;
+
+/// <summary>
+/// Stream wrapper that computes an incremental hash as data is read.
+/// </summary>
+internal sealed class HashingStream : Stream
+{
+    private readonly Stream _inner;
+    private readonly IncrementalHash _hash;
+    private readonly bool _leaveOpen;
+    private bool _disposed;
+
+    public HashingStream(Stream inner, bool leaveOpen = false, HashAlgorithmName? algorithm = null)
+    {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        if (!inner.CanRead)
+        {
+            throw new ArgumentException("The supplied stream must be readable.", nameof(inner));
+        }
+
+        _leaveOpen = leaveOpen;
+        _hash = IncrementalHash.CreateHash(algorithm ?? HashAlgorithmName.SHA256);
+    }
+
+    public long BytesProcessed { get; private set; }
+
+    public override bool CanRead => !_disposed && _inner.CanRead;
+    public override bool CanSeek => !_disposed && _inner.CanSeek;
+    public override bool CanWrite => false;
+    public override long Length => _inner.Length;
+
+    public override long Position
+    {
+        get => _inner.Position;
+        set => _inner.Position = value;
+    }
+
+    public byte[] GetHashAndReset()
+    {
+        EnsureNotDisposed();
+        return _hash.GetHashAndReset();
+    }
+
+    public override void Flush() => _inner.Flush();
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        var read = _inner.Read(buffer, offset, count);
+        if (read > 0)
+        {
+            _hash.AppendData(buffer, offset, read);
+            BytesProcessed += read;
+        }
+        return read;
+    }
+
+    public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        var read = await _inner.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+        if (read > 0)
+        {
+            _hash.AppendData(buffer, offset, read);
+            BytesProcessed += read;
+        }
+        return read;
+    }
+
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        => ReadAsyncCore(buffer, cancellationToken);
+
+    private async ValueTask<int> ReadAsyncCore(Memory<byte> buffer, CancellationToken cancellationToken)
+    {
+        var read = await _inner.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+        if (read > 0)
+        {
+            _hash.AppendData(buffer.Span[..read]);
+            BytesProcessed += read;
+        }
+        return read;
+    }
+
+    public override int ReadByte()
+    {
+        var value = _inner.ReadByte();
+        if (value >= 0)
+        {
+            Span<byte> buffer = stackalloc byte[1];
+            buffer[0] = (byte)value;
+            _hash.AppendData(buffer);
+            BytesProcessed++;
+        }
+        return value;
+    }
+
+    public override long Seek(long offset, SeekOrigin origin) => _inner.Seek(offset, origin);
+
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    protected override void Dispose(bool disposing)
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        if (disposing)
+        {
+            _hash.Dispose();
+            if (!_leaveOpen)
+            {
+                _inner.Dispose();
+            }
+        }
+
+        _disposed = true;
+        base.Dispose(disposing);
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _hash.Dispose();
+        if (!_leaveOpen)
+        {
+            await _inner.DisposeAsync().ConfigureAwait(false);
+        }
+
+        _disposed = true;
+        await base.DisposeAsync().ConfigureAwait(false);
+    }
+
+    private void EnsureNotDisposed()
+    {
+        if (_disposed)
+        {
+            throw new ObjectDisposedException(nameof(HashingStream));
+        }
+    }
+}

--- a/Lockb0x.Storage/Internal/HttpResponseStream.cs
+++ b/Lockb0x.Storage/Internal/HttpResponseStream.cs
@@ -1,0 +1,68 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Lockb0x.Storage.Internal;
+
+/// <summary>
+/// Wraps an HTTP response stream to ensure the originating response is disposed with the stream.
+/// </summary>
+internal sealed class HttpResponseStream : Stream
+{
+    private readonly Stream _inner;
+    private readonly HttpResponseMessage _response;
+
+    public HttpResponseStream(Stream inner, HttpResponseMessage response)
+    {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        _response = response ?? throw new ArgumentNullException(nameof(response));
+    }
+
+    public override bool CanRead => _inner.CanRead;
+    public override bool CanSeek => _inner.CanSeek;
+    public override bool CanWrite => false;
+    public override long Length => _inner.Length;
+
+    public override long Position
+    {
+        get => _inner.Position;
+        set => _inner.Position = value;
+    }
+
+    public override void Flush() => _inner.Flush();
+
+    public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        => _inner.ReadAsync(buffer, cancellationToken);
+
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        => _inner.ReadAsync(buffer, offset, count, cancellationToken);
+
+    public override int ReadByte() => _inner.ReadByte();
+
+    public override long Seek(long offset, SeekOrigin origin) => _inner.Seek(offset, origin);
+
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _inner.Dispose();
+            _response.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        await _inner.DisposeAsync().ConfigureAwait(false);
+        _response.Dispose();
+        await base.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/Lockb0x.Storage/IpfsStorageOptions.cs
+++ b/Lockb0x.Storage/IpfsStorageOptions.cs
@@ -1,0 +1,49 @@
+using System;
+
+namespace Lockb0x.Storage;
+
+/// <summary>
+/// Configuration for the IPFS storage adapter.
+/// </summary>
+public sealed class IpfsStorageOptions
+{
+    /// <summary>
+    /// API endpoint for the IPFS node (defaults to the local go-ipfs daemon).
+    /// </summary>
+    public Uri ApiEndpoint { get; init; } = new("http://127.0.0.1:5001/");
+
+    /// <summary>
+    /// Optional public gateway used for retrieval and metadata lookups.
+    /// </summary>
+    public Uri? GatewayEndpoint { get; init; } = new("https://ipfs.io/");
+
+    /// <summary>
+    /// Declared technical region in which content is pinned.
+    /// </summary>
+    public string Region { get; init; } = "global";
+
+    /// <summary>
+    /// Legal jurisdiction governing the storage provider.
+    /// </summary>
+    public string Jurisdiction { get; init; } = "UN";
+
+    /// <summary>
+    /// Name of the service provider responsible for storage custody.
+    /// </summary>
+    public string Provider { get; init; } = "IPFS";
+
+    /// <summary>
+    /// Whether files should be pinned on add.
+    /// </summary>
+    public bool PinByDefault { get; init; } = true;
+
+    /// <summary>
+    /// CID version to request when adding files (defaults to v1 as per spec guidance).
+    /// </summary>
+    public int CidVersion { get; init; } = 1;
+
+    /// <summary>
+    /// Whether to enable raw leaves when uploading (recommended for deterministic hashing).
+    /// </summary>
+    public bool UseRawLeaves { get; init; } = true;
+}

--- a/Lockb0x.Tests/StorageAdapterTests.cs
+++ b/Lockb0x.Tests/StorageAdapterTests.cs
@@ -1,2 +1,225 @@
-// File removed: not implemented in current state.
-// Tests temporarily disabled to allow SigningServiceTests to build and run.
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Lockb0x.Core.Utilities;
+using Lockb0x.Storage;
+using Lockb0x.Storage.Adapters;
+using Xunit;
+
+namespace Lockb0x.Tests;
+
+public class StorageAdapterTests
+{
+    [Fact]
+    public async Task StoreAsync_ComputesIntegrityProofAndMetadata()
+    {
+        var payload = Encoding.UTF8.GetBytes("hello world");
+        var sha = SHA256.HashData(payload);
+        var cid = CreateRawCid(sha);
+
+        var apiHandler = new StubHttpMessageHandler(async (request, token) =>
+        {
+            Assert.Equal(HttpMethod.Post, request.Method);
+            Assert.Contains("api/v0/add", request.RequestUri!.AbsoluteUri, StringComparison.Ordinal);
+            var body = await request.Content!.ReadAsStringAsync(token).ConfigureAwait(false);
+            Assert.Contains("hello world", body, StringComparison.Ordinal);
+
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent($"{{\"Name\":\"hello.txt\",\"Hash\":\"{cid}\",\"Size\":\"11\"}}\n", Encoding.UTF8, "application/json")
+            };
+            return response;
+        });
+
+        var options = new IpfsStorageOptions
+        {
+            ApiEndpoint = new Uri("http://localhost:5001/"),
+            GatewayEndpoint = null,
+            Region = "us-central1",
+            Jurisdiction = "US/CA",
+            Provider = "IPFS Cooperative"
+        };
+
+        await using var adapter = new IpfsStorageAdapter(options, new HttpClient(apiHandler) { BaseAddress = options.ApiEndpoint }, gatewayClient: null);
+        using var stream = new MemoryStream(payload);
+        var request = new StorageUploadRequest(stream, "hello.txt", "text/plain") { ContentLength = payload.Length };
+
+        var result = await adapter.StoreAsync(request, CancellationToken.None).ConfigureAwait(false);
+
+        Assert.Equal("ipfs", result.Descriptor.Protocol);
+        Assert.Equal(NiUri.Create(sha, "sha-256"), result.Descriptor.IntegrityProof);
+        Assert.Equal("text/plain", result.Descriptor.MediaType);
+        Assert.Equal(payload.Length, result.Descriptor.SizeBytes);
+        Assert.Equal("us-central1", result.Descriptor.Location.Region);
+        Assert.Equal("US/CA", result.Descriptor.Location.Jurisdiction);
+        Assert.Equal("IPFS Cooperative", result.Descriptor.Location.Provider);
+        Assert.Equal(cid, result.ContentIdentifier);
+        Assert.Equal($"ipfs://{cid}", result.ResourceUri);
+        var nativeMetadata = Assert.NotNull(result.NativeMetadata);
+        Assert.Contains("Name", nativeMetadata.Keys);
+    }
+
+    [Fact]
+    public async Task StoreAsync_ThrowsWhenCidDigestMismatch()
+    {
+        var payload = Encoding.UTF8.GetBytes("mismatch");
+        var incorrectDigest = new byte[32];
+        var mismatchedCid = CreateRawCid(incorrectDigest);
+
+        var apiHandler = new StubHttpMessageHandler(async (request, token) =>
+        {
+            await request.Content!.CopyToAsync(Stream.Null, token).ConfigureAwait(false);
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent($"{{\"Name\":\"doc.txt\",\"Hash\":\"{mismatchedCid}\",\"Size\":\"8\"}}\n", Encoding.UTF8, "application/json")
+            };
+            return response;
+        });
+
+        var options = new IpfsStorageOptions
+        {
+            ApiEndpoint = new Uri("http://localhost:5001/"),
+            GatewayEndpoint = null,
+            Region = "global",
+            Jurisdiction = "UN",
+            Provider = "IPFS"
+        };
+
+        await using var adapter = new IpfsStorageAdapter(options, new HttpClient(apiHandler) { BaseAddress = options.ApiEndpoint }, gatewayClient: null);
+        using var stream = new MemoryStream(payload);
+        var request = new StorageUploadRequest(stream, "doc.txt", "text/plain");
+
+        await Assert.ThrowsAsync<StorageAdapterException>(() => adapter.StoreAsync(request, CancellationToken.None)).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task GetMetadataAsync_UsesGatewayHeadersWhenAvailable()
+    {
+        var payload = Encoding.UTF8.GetBytes("gateway");
+        var digest = SHA256.HashData(payload);
+        var cid = CreateRawCid(digest);
+
+        var apiHandler = new StubHttpMessageHandler((request, token) =>
+        {
+            if (request.RequestUri!.AbsolutePath.Contains("block/stat", StringComparison.Ordinal))
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"Size\":7}\n", Encoding.UTF8, "application/json")
+                };
+                return Task.FromResult(response);
+            }
+
+            throw new InvalidOperationException($"Unexpected API call: {request.RequestUri}");
+        });
+
+        var gatewayHandler = new StubHttpMessageHandler((request, token) =>
+        {
+            if (request.Method == HttpMethod.Head)
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(string.Empty)
+                };
+                response.Content.Headers.ContentLength = payload.Length;
+                response.Content.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
+                return Task.FromResult(response);
+            }
+
+            throw new InvalidOperationException($"Unexpected gateway call: {request.Method} {request.RequestUri}");
+        });
+
+        var options = new IpfsStorageOptions
+        {
+            ApiEndpoint = new Uri("http://localhost:5001/"),
+            GatewayEndpoint = new Uri("https://gateway.example/"),
+            Region = "eu-west-1",
+            Jurisdiction = "EU/DE",
+            Provider = "Gateway Provider"
+        };
+
+        await using var adapter = new IpfsStorageAdapter(
+            options,
+            new HttpClient(apiHandler) { BaseAddress = options.ApiEndpoint },
+            new HttpClient(gatewayHandler) { BaseAddress = options.GatewayEndpoint });
+
+        var result = await adapter.GetMetadataAsync(cid, CancellationToken.None).ConfigureAwait(false);
+
+        Assert.Equal("ipfs", result.Descriptor.Protocol);
+        Assert.Equal(NiUri.Create(digest, "sha-256"), result.Descriptor.IntegrityProof);
+        Assert.Equal(payload.Length, result.Descriptor.SizeBytes);
+        Assert.Equal("text/plain", result.Descriptor.MediaType);
+        Assert.Equal("https://gateway.example/ipfs/" + cid, result.ResourceUri);
+        Assert.Equal("Gateway Provider", result.Descriptor.Location.Provider);
+        Assert.Equal("eu-west-1", result.Descriptor.Location.Region);
+        Assert.Equal("EU/DE", result.Descriptor.Location.Jurisdiction);
+        Assert.Equal(cid, result.ContentIdentifier);
+    }
+
+    private static string CreateRawCid(ReadOnlySpan<byte> digest)
+    {
+        if (digest.Length != 32)
+        {
+            throw new ArgumentException("SHA-256 digest must be 32 bytes.", nameof(digest));
+        }
+
+        Span<byte> payload = stackalloc byte[4 + digest.Length];
+        payload[0] = 0x01; // CIDv1
+        payload[1] = 0x55; // raw binary codec
+        payload[2] = 0x12; // sha2-256 multihash code
+        payload[3] = (byte)digest.Length;
+        digest.CopyTo(payload[4..]);
+
+        var encoded = EncodeBase32(payload);
+        return "b" + encoded;
+    }
+
+    private static string EncodeBase32(ReadOnlySpan<byte> data)
+    {
+        const string alphabet = "abcdefghijklmnopqrstuvwxyz234567";
+        if (data.IsEmpty)
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder((data.Length * 8 + 4) / 5);
+        int buffer = 0;
+        int bits = 0;
+        foreach (var b in data)
+        {
+            buffer = (buffer << 8) | b;
+            bits += 8;
+            while (bits >= 5)
+            {
+                bits -= 5;
+                builder.Append(alphabet[(buffer >> bits) & 0x1F]);
+            }
+        }
+
+        if (bits > 0)
+        {
+            builder.Append(alphabet[(buffer << (5 - bits)) & 0x1F]);
+        }
+
+        return builder.ToString();
+    }
+
+    private sealed class StubHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _handler;
+
+        public StubHttpMessageHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
+        {
+            _handler = handler;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => _handler(request, cancellationToken);
+    }
+}


### PR DESCRIPTION
## Summary
- replace the storage adapter contract with stream-based requests and rich results to match the Lockb0x spec
- add an IPFS storage adapter with CID validation, metadata enrichment, and retrieval helpers plus supporting utilities
- document adapter configuration options and cover the new behaviour with unit tests

## Testing
- `dotnet test` *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68df0cb519ac832db7026ee23889e3bf