### PR TITLE
Implement Lockb0x certificate issuance and validation

### DIFF
--- a/Lockb0x.Certificates/CertificateService.cs
+++ b/Lockb0x.Certificates/CertificateService.cs
@@ -1,0 +1,891 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Formats.Cbor;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Linq;
+using Lockb0x.Certificates.Models;
+using Lockb0x.Certificates.Stores;
+using Lockb0x.Core.Canonicalization;
+using Lockb0x.Core.Models;
+using Lockb0x.Core.Utilities;
+using Lockb0x.Core.Validation;
+using Lockb0x.Signing;
+
+namespace Lockb0x.Certificates;
+
+/// <summary>
+/// Reference implementation of the Lockb0x certificate issuance and validation workflow.
+/// </summary>
+public sealed class CertificateService : ICertificateService
+{
+    private const string EntryHashOid = "1.3.6.1.4.1.58543.100.1";
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = null,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = false
+    };
+
+    private readonly IJsonCanonicalizer _canonicalizer;
+    private readonly ISigningService _signingService;
+    private readonly ICodexEntryValidator _validator;
+    private readonly ICertificateStore _store;
+    private readonly HashAlgorithmName _hashAlgorithm;
+
+    public CertificateService()
+        : this(new JcsCanonicalizer(), new JoseCoseSigningService(), new CodexEntryValidator(), new InMemoryCertificateStore(), HashAlgorithmName.SHA256)
+    {
+    }
+
+    public CertificateService(
+        IJsonCanonicalizer canonicalizer,
+        ISigningService signingService,
+        ICodexEntryValidator validator,
+        ICertificateStore store,
+        HashAlgorithmName? hashAlgorithm = null)
+    {
+        _canonicalizer = canonicalizer ?? throw new ArgumentNullException(nameof(canonicalizer));
+        _signingService = signingService ?? throw new ArgumentNullException(nameof(signingService));
+        _validator = validator ?? throw new ArgumentNullException(nameof(validator));
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _hashAlgorithm = hashAlgorithm ?? HashAlgorithmName.SHA256;
+    }
+
+    public async Task<CertificateDescriptor> IssueCertificateAsync(CodexEntry entry, CertificateOptions options, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(options.SigningKey);
+
+        var validation = _validator.Validate(entry);
+        if (!validation.Success)
+        {
+            var errors = string.Join(", ", validation.Errors.Select(e => $"{e.Code}:{e.Message}"));
+            throw new InvalidOperationException($"Codex entry failed validation and cannot be certified: {errors}");
+        }
+
+        if (entry.Signatures is null || entry.Signatures.Count == 0)
+        {
+            throw new InvalidOperationException("Codex entries must contain signatures before certificate issuance.");
+        }
+
+        var issuer = options.Issuer ?? entry.Identity.Org;
+        if (string.IsNullOrWhiteSpace(issuer))
+        {
+            throw new InvalidOperationException("A certificate issuer must be provided via options or entry identity.");
+        }
+
+        var subject = options.Subject ?? entry.Identity.Subject ?? entry.Id;
+        if (string.IsNullOrWhiteSpace(subject))
+        {
+            throw new InvalidOperationException("A certificate subject could not be derived from the Codex entry.");
+        }
+
+        if (string.IsNullOrWhiteSpace(options.SigningKey.KeyId))
+        {
+            throw new InvalidOperationException("Signing keys must include a stable key identifier (kid).");
+        }
+
+        if (string.IsNullOrWhiteSpace(options.SigningKey.PrivateKey))
+        {
+            throw new InvalidOperationException("Signing keys must include private key material for issuance operations.");
+        }
+
+        var certificateId = !string.IsNullOrWhiteSpace(options.CertificateId)
+            ? options.CertificateId!
+            : $"urn:uuid:{Guid.NewGuid()}";
+
+        var issuedAt = options.IssuedAt ?? DateTimeOffset.UtcNow;
+        var entryHashBytes = _canonicalizer.Hash(entry, _hashAlgorithm);
+        var entryHash = NiUri.Create(entryHashBytes, _hashAlgorithm);
+
+        var representations = new List<CertificateRepresentation>();
+        var formats = options.Formats?.Distinct().ToList() ?? new List<CertificateFormat>();
+        if (formats.Count == 0)
+        {
+            throw new InvalidOperationException("At least one certificate format must be requested.");
+        }
+
+        foreach (var format in formats)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            switch (format)
+            {
+                case CertificateFormat.Json:
+                    representations.Add(await CreateJsonRepresentationAsync(entry, options, certificateId, issuer, subject, issuedAt, entryHash).ConfigureAwait(false));
+                    break;
+                case CertificateFormat.VerifiableCredential:
+                    representations.Add(await CreateVerifiableCredentialRepresentationAsync(entry, options, certificateId, issuer, subject, issuedAt, entryHash).ConfigureAwait(false));
+                    break;
+                case CertificateFormat.Jwt:
+                    representations.Add(await CreateJwtRepresentationAsync(entry, options, certificateId, issuer, subject, issuedAt, entryHash).ConfigureAwait(false));
+                    break;
+                case CertificateFormat.Cwt:
+                    representations.Add(await CreateCwtRepresentationAsync(entry, options, certificateId, issuer, subject, issuedAt, entryHash, entryHashBytes).ConfigureAwait(false));
+                    break;
+                case CertificateFormat.X509:
+                    representations.Add(CreateX509Representation(entry, options, certificateId, issuer, subject, issuedAt, entryHashBytes));
+                    break;
+                default:
+                    throw new NotSupportedException($"Unsupported certificate format '{format}'.");
+            }
+        }
+
+        var descriptor = new CertificateDescriptor(
+            certificateId,
+            entry.Id,
+            issuer,
+            subject,
+            options.Purpose,
+            issuedAt,
+            options.ExpiresAt,
+            CertificateStatus.Active,
+            new ReadOnlyCollection<CertificateRepresentation>(representations),
+            new ReadOnlyCollection<CertificateEvent>(new List<CertificateEvent>
+            {
+                new("issued", issuedAt, "Certificate issued.")
+            }));
+
+        await _store.SaveAsync(descriptor, cancellationToken).ConfigureAwait(false);
+        return descriptor;
+    }
+
+    public async Task<CertificateValidationResult> ValidateCertificateAsync(CertificateDescriptor certificate, CodexEntry entry, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(certificate);
+        ArgumentNullException.ThrowIfNull(entry);
+
+        var result = new CertificateValidationResult();
+        if (!string.Equals(certificate.EntryId, entry.Id, StringComparison.Ordinal))
+        {
+            return result.AddError("Certificate entry id does not match supplied Codex entry.");
+        }
+
+        if (certificate.Status == CertificateStatus.Revoked)
+        {
+            result.AddError("Certificate has been revoked.");
+        }
+
+        if (certificate.ExpiresAt is not null && certificate.ExpiresAt <= DateTimeOffset.UtcNow)
+        {
+            result.AddError("Certificate has expired.");
+        }
+
+        var validation = _validator.Validate(entry);
+        if (!validation.Success)
+        {
+            foreach (var error in validation.Errors)
+            {
+                result.AddError($"Codex entry invalid: {error.Code} - {error.Message}");
+            }
+        }
+
+        if (!result.Success)
+        {
+            return result;
+        }
+
+        var entryHashBytes = _canonicalizer.Hash(entry, _hashAlgorithm);
+        var entryHash = NiUri.Create(entryHashBytes, _hashAlgorithm);
+
+        foreach (var representation in certificate.Representations)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            switch (representation)
+            {
+                case JsonCertificateRepresentation json:
+                    ValidateEntryHash(json.EntryHash, entryHash, result);
+                    try
+                    {
+                        await ValidateJsonRepresentationAsync(json, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        result.AddError($"JSON certificate validation failed: {ex.Message}");
+                    }
+                    break;
+                case VerifiableCredentialRepresentation vc:
+                    ValidateEntryHash(vc.EntryHash, entryHash, result);
+                    try
+                    {
+                        await ValidateVerifiableCredentialAsync(vc, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        result.AddError($"Verifiable credential validation failed: {ex.Message}");
+                    }
+                    break;
+                case JwtCertificateRepresentation jwt:
+                    ValidateEntryHash(jwt.EntryHash, entryHash, result);
+                    try
+                    {
+                        await ValidateJwtAsync(jwt, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        result.AddError($"JWT validation failed: {ex.Message}");
+                    }
+                    break;
+                case CwtCertificateRepresentation cwt:
+                    ValidateEntryHash(cwt.EntryHash, entryHash, result);
+                    try
+                    {
+                        await ValidateCwtAsync(cwt, entryHashBytes, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        result.AddError($"CWT validation failed: {ex.Message}");
+                    }
+                    break;
+                case X509CertificateRepresentation x509:
+                    ValidateX509(x509, entryHashBytes, result);
+                    break;
+            }
+        }
+
+        return result;
+    }
+
+    public async Task<bool> RevokeCertificateAsync(string certificateId, string? reason = null, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(certificateId))
+        {
+            return false;
+        }
+
+        var existing = await _store.GetAsync(certificateId, cancellationToken).ConfigureAwait(false);
+        if (existing is null)
+        {
+            return false;
+        }
+
+        if (existing.Status == CertificateStatus.Revoked)
+        {
+            return true;
+        }
+
+        var revokedAt = DateTimeOffset.UtcNow;
+        var updated = existing.WithStatus(
+            CertificateStatus.Revoked,
+            new[] { new CertificateEvent("revoked", revokedAt, reason ?? "Certificate revoked.") });
+
+        await _store.UpdateAsync(updated, cancellationToken).ConfigureAwait(false);
+        return true;
+    }
+
+    public Task<CertificateDescriptor?> GetCertificateAsync(string certificateId, CancellationToken cancellationToken = default)
+        => _store.GetAsync(certificateId, cancellationToken);
+
+    private async Task<JsonCertificateRepresentation> CreateJsonRepresentationAsync(
+        CodexEntry entry,
+        CertificateOptions options,
+        string certificateId,
+        string issuer,
+        string subject,
+        DateTimeOffset issuedAt,
+        string entryHash)
+    {
+        var document = new JsonCertificateDocument
+        {
+            CertificateType = "lockb0x-json",
+            CertificateId = certificateId,
+            CodexEntryId = entry.Id,
+            ProtocolVersion = options.ProtocolVersion ?? entry.Version,
+            IssuedAt = issuedAt,
+            ExpiresAt = options.ExpiresAt,
+            Issuer = issuer,
+            Subject = subject,
+            Purpose = options.Purpose.ToString().ToLowerInvariant(),
+            EntryHash = entryHash,
+            Identity = entry.Identity,
+            Encryption = entry.Encryption,
+            Storage = entry.Storage,
+            Anchor = entry.Anchor,
+            Signatures = entry.Signatures,
+            AdditionalMetadata = options.AdditionalMetadata
+        };
+
+        var canonical = _canonicalizer.Canonicalize(document);
+        var signature = await _signingService.SignAsync(Encoding.UTF8.GetBytes(canonical), options.SigningKey, options.SigningAlgorithm).ConfigureAwait(false);
+        var json = Serialize(document);
+        return new JsonCertificateRepresentation(json, canonical, signature, document.ProtocolVersion, entryHash);
+    }
+
+    private async Task<VerifiableCredentialRepresentation> CreateVerifiableCredentialRepresentationAsync(
+        CodexEntry entry,
+        CertificateOptions options,
+        string certificateId,
+        string issuer,
+        string subject,
+        DateTimeOffset issuedAt,
+        string entryHash)
+    {
+        var credentialSubject = new CredentialSubjectDocument
+        {
+            Id = subject,
+            CodexEntryId = entry.Id,
+            EntryHash = entryHash,
+            Purpose = options.Purpose.ToString().ToLowerInvariant(),
+            Anchor = entry.Anchor,
+            Storage = entry.Storage,
+            Encryption = entry.Encryption,
+            Identity = entry.Identity
+        };
+
+        var vcWithoutProof = new VerifiableCredentialDocument
+        {
+            Context = options.VerifiableCredentialContexts.Select(c => (object)c).ToList(),
+            Id = certificateId,
+            Type = new List<string> { "VerifiableCredential", "Lockb0xCertificate" },
+            Issuer = issuer,
+            IssuanceDate = issuedAt,
+            ExpirationDate = options.ExpiresAt,
+            CredentialSubject = credentialSubject
+        };
+
+        var canonical = _canonicalizer.Canonicalize(vcWithoutProof);
+        var canonicalSignature = await _signingService.SignAsync(Encoding.UTF8.GetBytes(canonical), options.SigningKey, options.SigningAlgorithm).ConfigureAwait(false);
+        var jws = await CreateJwsAsync(canonicalSignature.ProtectedHeader, canonical, options, "vc+jwt").ConfigureAwait(false);
+
+        var proof = new VerifiableCredentialProof
+        {
+            Type = "JsonWebSignature2020",
+            Created = issuedAt,
+            ProofPurpose = "assertionMethod",
+            VerificationMethod = canonicalSignature.ProtectedHeader.KeyId ?? options.SigningKey.KeyId ?? issuer,
+            Jws = jws
+        };
+
+        var vc = vcWithoutProof with { Proof = proof };
+        var credential = Serialize(vc);
+        return new VerifiableCredentialRepresentation(credential, canonical, canonicalSignature, options.VerifiableCredentialContexts, entryHash, jws);
+    }
+
+    private async Task<JwtCertificateRepresentation> CreateJwtRepresentationAsync(
+        CodexEntry entry,
+        CertificateOptions options,
+        string certificateId,
+        string issuer,
+        string subject,
+        DateTimeOffset issuedAt,
+        string entryHash)
+    {
+        var audience = options.Audience ?? "lockb0x";
+        var payload = new JwtPayloadDocument
+        {
+            Issuer = issuer,
+            Subject = subject,
+            Audience = audience,
+            IssuedAt = issuedAt.ToUnixTimeSeconds(),
+            ExpiresAt = options.ExpiresAt?.ToUnixTimeSeconds(),
+            TokenId = certificateId,
+            EntryId = entry.Id,
+            EntryHash = entryHash,
+            Anchor = entry.Anchor,
+            Storage = entry.Storage,
+            Purpose = options.Purpose.ToString().ToLowerInvariant()
+        };
+
+        var payloadJson = Serialize(payload);
+        var payloadB64 = Base64UrlEncoder.Encode(Encoding.UTF8.GetBytes(payloadJson));
+
+        var header = new JwtHeaderDocument
+        {
+            Algorithm = options.SigningAlgorithm,
+            Type = "JWT",
+            KeyId = options.SigningKey.KeyId
+        };
+
+        var headerJson = Serialize(header);
+        var headerB64 = Base64UrlEncoder.Encode(Encoding.UTF8.GetBytes(headerJson));
+        var signingInput = Encoding.UTF8.GetBytes($"{headerB64}.{payloadB64}");
+        var signature = await _signingService.SignAsync(signingInput, options.SigningKey, options.SigningAlgorithm).ConfigureAwait(false);
+        var token = $"{headerB64}.{payloadB64}.{signature.Signature}";
+        return new JwtCertificateRepresentation(token, headerJson, payloadJson, signature, entryHash);
+    }
+
+    private async Task<CwtCertificateRepresentation> CreateCwtRepresentationAsync(
+        CodexEntry entry,
+        CertificateOptions options,
+        string certificateId,
+        string issuer,
+        string subject,
+        DateTimeOffset issuedAt,
+        string entryHash,
+        byte[] entryHashBytes)
+    {
+        var writer = new CborWriter();
+        writer.WriteStartMap(11);
+        writer.WriteInt32(1); // iss
+        writer.WriteTextString(issuer);
+        writer.WriteInt32(2); // sub
+        writer.WriteTextString(subject);
+        writer.WriteInt32(3); // aud
+        writer.WriteTextString(options.Audience ?? "lockb0x");
+        var expires = options.ExpiresAt ?? issuedAt.AddYears(1);
+        writer.WriteInt32(4); // exp
+        writer.WriteInt64(expires.ToUnixTimeSeconds());
+        writer.WriteInt32(5); // nbf
+        writer.WriteInt64(issuedAt.ToUnixTimeSeconds());
+        writer.WriteInt32(6); // iat
+        writer.WriteInt64(issuedAt.ToUnixTimeSeconds());
+        writer.WriteInt32(7); // cti
+        writer.WriteTextString(certificateId);
+        writer.WriteInt32(1000); // Lockb0x entry hash (custom claim)
+        writer.WriteByteString(entryHashBytes);
+        writer.WriteInt32(1001); // Anchor chain
+        writer.WriteTextString(entry.Anchor.Chain);
+        writer.WriteInt32(1002); // Anchor transaction hash
+        writer.WriteTextString(entry.Anchor.TransactionHash);
+        writer.WriteInt32(1003); // Purpose
+        writer.WriteTextString(options.Purpose.ToString().ToLowerInvariant());
+        writer.WriteEndMap();
+
+        var payload = writer.Encode();
+        var signature = await _signingService.SignAsync(payload, options.SigningKey, options.SigningAlgorithm).ConfigureAwait(false);
+        return new CwtCertificateRepresentation(payload, signature, entryHash);
+    }
+
+    private X509CertificateRepresentation CreateX509Representation(
+        CodexEntry entry,
+        CertificateOptions options,
+        string certificateId,
+        string issuer,
+        string subject,
+        DateTimeOffset issuedAt,
+        byte[] entryHashBytes)
+    {
+        using var rsa = RSA.Create(2048);
+        var distinguishedName = CreateDistinguishedName(subject);
+        var issuerName = CreateDistinguishedName(issuer);
+        var request = new CertificateRequest(distinguishedName, rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        request.CertificateExtensions.Add(new X509BasicConstraintsExtension(false, false, 0, false));
+        request.CertificateExtensions.Add(new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature, true));
+        request.CertificateExtensions.Add(new X509SubjectKeyIdentifierExtension(request.PublicKey, false));
+
+        var writer = new System.Formats.Asn1.AsnWriter(System.Formats.Asn1.AsnEncodingRules.DER);
+        writer.WriteOctetString(entryHashBytes);
+        request.CertificateExtensions.Add(new X509Extension(new Oid(EntryHashOid), writer.Encode(), critical: true));
+
+        var notBefore = issuedAt.AddMinutes(-5);
+        var notAfter = options.ExpiresAt ?? issuedAt.AddYears(1);
+        using var certificate = request.CreateSelfSigned(notBefore, notAfter);
+        certificate.FriendlyName = $"Lockb0x Certificate {certificateId}";
+        return new X509CertificateRepresentation(certificate.Export(X509ContentType.Cert), _hashAlgorithm.Name.ToLowerInvariant(), entryHashBytes);
+    }
+
+    private static X500DistinguishedName CreateDistinguishedName(string value)
+    {
+        var escaped = value.Replace(",", "+", StringComparison.Ordinal).Replace("\"", "'", StringComparison.Ordinal);
+        return new X500DistinguishedName($"CN={escaped}");
+    }
+
+    private static string Serialize<T>(T value) => JsonSerializer.Serialize(value, SerializerOptions);
+
+    private static void ValidateEntryHash(string representationHash, string expectedHash, CertificateValidationResult result)
+    {
+        if (!string.Equals(representationHash, expectedHash, StringComparison.Ordinal))
+        {
+            result.AddError("Certificate representation hash does not match Codex entry hash.");
+        }
+    }
+
+    private async Task ValidateJsonRepresentationAsync(JsonCertificateRepresentation representation, CancellationToken cancellationToken)
+    {
+        var canonicalBytes = Encoding.UTF8.GetBytes(representation.CanonicalForm);
+        if (!await _signingService.VerifyAsync(canonicalBytes, representation.Signature).ConfigureAwait(false))
+        {
+            throw new InvalidOperationException("JSON certificate signature verification failed.");
+        }
+    }
+
+    private async Task ValidateVerifiableCredentialAsync(VerifiableCredentialRepresentation representation, CancellationToken cancellationToken)
+    {
+        var canonicalBytes = Encoding.UTF8.GetBytes(representation.CanonicalForm);
+        if (!await _signingService.VerifyAsync(canonicalBytes, representation.Proof).ConfigureAwait(false))
+        {
+            throw new InvalidOperationException("Verifiable credential proof validation failed.");
+        }
+
+        if (!await ValidateJwsAsync(representation.Jws, canonicalBytes).ConfigureAwait(false))
+        {
+            throw new InvalidOperationException("Verifiable credential JWS could not be validated.");
+        }
+    }
+
+    private async Task ValidateJwtAsync(JwtCertificateRepresentation representation, CancellationToken cancellationToken)
+    {
+        var parts = representation.Token.Split('.');
+        if (parts.Length != 3)
+        {
+            throw new InvalidOperationException("JWT representation is malformed.");
+        }
+
+        var signingInput = Encoding.UTF8.GetBytes($"{parts[0]}.{parts[1]}");
+        var signature = new SignatureProof
+        {
+            ProtectedHeader = new SignatureProtectedHeader
+            {
+                Algorithm = representation.Signature.ProtectedHeader.Algorithm,
+                KeyId = representation.Signature.ProtectedHeader.KeyId
+            },
+            Signature = parts[2]
+        };
+
+        if (!await _signingService.VerifyAsync(signingInput, signature).ConfigureAwait(false))
+        {
+            throw new InvalidOperationException("JWT signature validation failed.");
+        }
+    }
+
+    private async Task ValidateCwtAsync(CwtCertificateRepresentation representation, byte[] expectedEntryHash, CancellationToken cancellationToken)
+    {
+        var reader = new CborReader(representation.Payload);
+        var mapLength = reader.ReadStartMap();
+        byte[]? hash = null;
+        if (mapLength is null)
+        {
+            while (reader.PeekState() != CborReaderState.EndMap)
+            {
+                var key = reader.ReadInt32();
+                if (key == 1000)
+                {
+                    hash = reader.ReadByteString();
+                }
+                else
+                {
+                    reader.SkipValue();
+                }
+            }
+        }
+        else
+        {
+            for (var i = 0; i < mapLength.Value; i++)
+            {
+                var key = reader.ReadInt32();
+                if (key == 1000)
+                {
+                    hash = reader.ReadByteString();
+                }
+                else
+                {
+                    reader.SkipValue();
+                }
+            }
+        }
+        reader.ReadEndMap();
+
+        if (hash is null || !hash.AsSpan().SequenceEqual(expectedEntryHash))
+        {
+            throw new InvalidOperationException("CWT representation entry hash mismatch.");
+        }
+
+        if (!await _signingService.VerifyAsync(representation.Payload, representation.Signature).ConfigureAwait(false))
+        {
+            throw new InvalidOperationException("CWT signature validation failed.");
+        }
+    }
+
+    private static void ValidateX509(X509CertificateRepresentation representation, byte[] expectedEntryHash, CertificateValidationResult result)
+    {
+        using var certificate = new X509Certificate2(representation.Certificate);
+        var extension = certificate.Extensions[EntryHashOid];
+        if (extension is null)
+        {
+            result.AddError("X.509 certificate missing Codex entry hash extension.");
+            return;
+        }
+
+        var raw = extension.RawData;
+        var reader = new System.Formats.Asn1.AsnReader(raw, System.Formats.Asn1.AsnEncodingRules.DER);
+        var hash = reader.ReadOctetString();
+        if (!hash.AsSpan().SequenceEqual(expectedEntryHash))
+        {
+            result.AddError("X.509 certificate Codex entry hash mismatch.");
+        }
+
+        if (certificate.NotAfter < DateTimeOffset.UtcNow)
+        {
+            result.AddError("X.509 certificate has expired.");
+        }
+    }
+
+    private async Task<string> CreateJwsAsync(SignatureProtectedHeader headerTemplate, string canonical, CertificateOptions options, string? type)
+    {
+        var header = new JwsHeader
+        {
+            Algorithm = headerTemplate.Algorithm,
+            KeyId = headerTemplate.KeyId ?? options.SigningKey.KeyId,
+            Type = type
+        };
+
+        var headerJson = Serialize(header);
+        var headerB64 = Base64UrlEncoder.Encode(Encoding.UTF8.GetBytes(headerJson));
+        var payloadB64 = Base64UrlEncoder.Encode(Encoding.UTF8.GetBytes(canonical));
+        var signingInput = Encoding.UTF8.GetBytes($"{headerB64}.{payloadB64}");
+        var signature = await _signingService.SignAsync(signingInput, options.SigningKey, options.SigningAlgorithm).ConfigureAwait(false);
+        return $"{headerB64}.{payloadB64}.{signature.Signature}";
+    }
+
+    private async Task<bool> ValidateJwsAsync(string token, byte[] canonicalBytes)
+    {
+        var parts = token.Split('.');
+        if (parts.Length != 3)
+        {
+            return false;
+        }
+
+        var payload = Base64UrlEncoder.Decode(parts[1]);
+        if (!payload.AsSpan().SequenceEqual(canonicalBytes))
+        {
+            return false;
+        }
+
+        var headerJson = Encoding.UTF8.GetString(Base64UrlEncoder.Decode(parts[0]));
+        var header = JsonSerializer.Deserialize<JwsHeader>(headerJson, SerializerOptions);
+        if (header is null)
+        {
+            return false;
+        }
+
+        var signature = new SignatureProof
+        {
+            ProtectedHeader = new SignatureProtectedHeader
+            {
+                Algorithm = header.Algorithm,
+                KeyId = header.KeyId
+            },
+            Signature = parts[2]
+        };
+
+        return await _signingService.VerifyAsync(Encoding.UTF8.GetBytes($"{parts[0]}.{parts[1]}"), signature).ConfigureAwait(false);
+    }
+
+    private sealed record JsonCertificateDocument
+    {
+        [JsonPropertyName("certificate_type")]
+        public required string CertificateType { get; init; }
+
+        [JsonPropertyName("certificate_id")]
+        public required string CertificateId { get; init; }
+
+        [JsonPropertyName("codex_entry_id")]
+        public required string CodexEntryId { get; init; }
+
+        [JsonPropertyName("protocol_version")]
+        public required string ProtocolVersion { get; init; }
+
+        [JsonPropertyName("issued_at")]
+        public required DateTimeOffset IssuedAt { get; init; }
+
+        [JsonPropertyName("expires_at")]
+        public DateTimeOffset? ExpiresAt { get; init; }
+
+        [JsonPropertyName("issuer")]
+        public required string Issuer { get; init; }
+
+        [JsonPropertyName("subject")]
+        public required string Subject { get; init; }
+
+        [JsonPropertyName("purpose")]
+        public required string Purpose { get; init; }
+
+        [JsonPropertyName("entry_hash")]
+        public required string EntryHash { get; init; }
+
+        [JsonPropertyName("identity")]
+        public required IdentityDescriptor Identity { get; init; }
+
+        [JsonPropertyName("encryption")]
+        public EncryptionDescriptor? Encryption { get; init; }
+
+        [JsonPropertyName("storage")]
+        public required StorageDescriptor Storage { get; init; }
+
+        [JsonPropertyName("anchor")]
+        public required AnchorProof Anchor { get; init; }
+
+        [JsonPropertyName("signatures")]
+        public required IReadOnlyList<SignatureProof> Signatures { get; init; }
+
+        [JsonPropertyName("additional_metadata")]
+        public IReadOnlyDictionary<string, string>? AdditionalMetadata { get; init; }
+    }
+
+    private sealed record CredentialSubjectDocument
+    {
+        [JsonPropertyName("id")]
+        public required string Id { get; init; }
+
+        [JsonPropertyName("codex_entry_id")]
+        public required string CodexEntryId { get; init; }
+
+        [JsonPropertyName("entry_hash")]
+        public required string EntryHash { get; init; }
+
+        [JsonPropertyName("purpose")]
+        public required string Purpose { get; init; }
+
+        [JsonPropertyName("identity")]
+        public required IdentityDescriptor Identity { get; init; }
+
+        [JsonPropertyName("storage")]
+        public required StorageDescriptor Storage { get; init; }
+
+        [JsonPropertyName("anchor")]
+        public required AnchorProof Anchor { get; init; }
+
+        [JsonPropertyName("encryption")]
+        public EncryptionDescriptor? Encryption { get; init; }
+    }
+
+    private sealed record VerifiableCredentialDocument
+    {
+        [JsonPropertyName("@context")]
+        public required List<object> Context { get; init; }
+
+        [JsonPropertyName("id")]
+        public required string Id { get; init; }
+
+        [JsonPropertyName("type")]
+        public required List<string> Type { get; init; }
+
+        [JsonPropertyName("issuer")]
+        public required string Issuer { get; init; }
+
+        [JsonPropertyName("issuanceDate")]
+        public required DateTimeOffset IssuanceDate { get; init; }
+
+        [JsonPropertyName("expirationDate")]
+        public DateTimeOffset? ExpirationDate { get; init; }
+
+        [JsonPropertyName("credentialSubject")]
+        public required CredentialSubjectDocument CredentialSubject { get; init; }
+
+        [JsonPropertyName("proof")]
+        public VerifiableCredentialProof? Proof { get; init; }
+    }
+
+    private sealed record VerifiableCredentialProof
+    {
+        [JsonPropertyName("type")]
+        public required string Type { get; init; }
+
+        [JsonPropertyName("created")]
+        public required DateTimeOffset Created { get; init; }
+
+        [JsonPropertyName("proofPurpose")]
+        public required string ProofPurpose { get; init; }
+
+        [JsonPropertyName("verificationMethod")]
+        public required string VerificationMethod { get; init; }
+
+        [JsonPropertyName("jws")]
+        public required string Jws { get; init; }
+    }
+
+    private sealed record JwtHeaderDocument
+    {
+        [JsonPropertyName("alg")]
+        public required string Algorithm { get; init; }
+
+        [JsonPropertyName("typ")]
+        public required string Type { get; init; }
+
+        [JsonPropertyName("kid")]
+        public string? KeyId { get; init; }
+    }
+
+    private sealed record JwtPayloadDocument
+    {
+        [JsonPropertyName("iss")]
+        public required string Issuer { get; init; }
+
+        [JsonPropertyName("sub")]
+        public required string Subject { get; init; }
+
+        [JsonPropertyName("aud")]
+        public required string Audience { get; init; }
+
+        [JsonPropertyName("iat")]
+        public required long IssuedAt { get; init; }
+
+        [JsonPropertyName("exp")]
+        public long? ExpiresAt { get; init; }
+
+        [JsonPropertyName("jti")]
+        public required string TokenId { get; init; }
+
+        [JsonPropertyName("codex_entry_id")]
+        public required string EntryId { get; init; }
+
+        [JsonPropertyName("entry_hash")]
+        public required string EntryHash { get; init; }
+
+        [JsonPropertyName("anchor")]
+        public required AnchorProof Anchor { get; init; }
+
+        [JsonPropertyName("storage")]
+        public required StorageDescriptor Storage { get; init; }
+
+        [JsonPropertyName("purpose")]
+        public required string Purpose { get; init; }
+    }
+
+    private sealed record JwsHeader
+    {
+        [JsonPropertyName("alg")]
+        public required string Algorithm { get; init; }
+
+        [JsonPropertyName("kid")]
+        public string? KeyId { get; init; }
+
+        [JsonPropertyName("typ")]
+        public string? Type { get; init; }
+    }
+
+    private static class Base64UrlEncoder
+    {
+        public static string Encode(ReadOnlySpan<byte> data)
+        {
+            var base64 = Convert.ToBase64String(data);
+            return base64.TrimEnd('=').Replace('+', '-').Replace('/', '_');
+        }
+
+        public static byte[] Decode(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return Array.Empty<byte>();
+            }
+
+            var builder = new StringBuilder(value.Length);
+            foreach (var c in value)
+            {
+                builder.Append(c switch
+                {
+                    '-' => '+',
+                    '_' => '/',
+                    _ => c
+                });
+            }
+
+            var padded = builder.ToString();
+            switch (padded.Length % 4)
+            {
+                case 2:
+                    padded += "==";
+                    break;
+                case 3:
+                    padded += "=";
+                    break;
+            }
+
+            return Convert.FromBase64String(padded);
+        }
+    }
+}

--- a/Lockb0x.Certificates/Class1.cs
+++ b/Lockb0x.Certificates/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace Lockb0x.Certificates;
-
-public class Class1
-{
-
-}

--- a/Lockb0x.Certificates/ICertificateService.cs
+++ b/Lockb0x.Certificates/ICertificateService.cs
@@ -1,50 +1,32 @@
+using System.Threading;
 using System.Threading.Tasks;
-using Lockb0x.Core;
+using Lockb0x.Certificates.Models;
+using Lockb0x.Core.Models;
 
 namespace Lockb0x.Certificates;
 
+/// <summary>
+/// Defines the certificate issuance, retrieval, and validation contract for Lockb0x Codex entries.
+/// </summary>
 public interface ICertificateService
 {
-    Task<Certificate> IssueCertificateAsync(CodexEntry entry);
-    Task<bool> VerifyCertificateAsync(Certificate certificate, CodexEntry entry);
-}
+    /// <summary>
+    /// Issues a certificate for the supplied Codex entry using the provided options.
+    /// </summary>
+    Task<CertificateDescriptor> IssueCertificateAsync(CodexEntry entry, CertificateOptions options, CancellationToken cancellationToken = default);
 
-public class Certificate
-{
-    public string Id { get; set; } = string.Empty;
-    public string Type { get; set; } = "Lockb0xCertificate";
-    public string Issuer { get; set; } = string.Empty;
-    public string Subject { get; set; } = string.Empty;
-    public string Jws { get; set; } = string.Empty; // JWS binding
-    public DateTimeOffset IssuedAt { get; set; }
-    public DateTimeOffset? RevokedAt { get; set; }
-    public string? Vc { get; set; } // Optional VC binding
-    public string? X509 { get; set; } // Optional X.509 binding
-}
+    /// <summary>
+    /// Validates the supplied certificate against the given Codex entry.
+    /// </summary>
+    Task<CertificateValidationResult> ValidateCertificateAsync(CertificateDescriptor certificate, CodexEntry entry, CancellationToken cancellationToken = default);
 
-// Stub implementation
-public class CertificateService : ICertificateService
-{
-    public async Task<Certificate> IssueCertificateAsync(CodexEntry entry)
-    {
-        // TODO: Real issuer/subject resolution, JWS/VC/X.509 generation
-        var cert = new Certificate
-        {
-            Id = $"urn:uuid:{Guid.NewGuid()}",
-            Issuer = "did:example:issuer", // TODO: Real issuer
-            Subject = entry.Id ?? "did:example:subject", // TODO: Real subject
-            IssuedAt = DateTimeOffset.UtcNow,
-            Jws = "stub-jws-for-entry" // TODO: Real JWS binding
-        };
-        return await Task.FromResult(cert);
-    }
+    /// <summary>
+    /// Marks the certificate as revoked and records an audit event.
+    /// </summary>
+    Task<bool> RevokeCertificateAsync(string certificateId, string? reason = null, CancellationToken cancellationToken = default);
 
-    public async Task<bool> VerifyCertificateAsync(Certificate certificate, CodexEntry entry)
-    {
-        // TODO: Real JWS/VC/X.509 verification
-        if (string.IsNullOrEmpty(certificate.Jws))
-            return await Task.FromResult(false);
-        // Stub: check subject matches entry id
-        return await Task.FromResult(certificate.Subject == entry.Id || string.IsNullOrEmpty(entry.Id));
-    }
+    /// <summary>
+    /// Retrieves a previously issued certificate by identifier.
+    /// </summary>
+    Task<CertificateDescriptor?> GetCertificateAsync(string certificateId, CancellationToken cancellationToken = default);
 }

--- a/Lockb0x.Certificates/Lockb0x.Certificates.csproj
+++ b/Lockb0x.Certificates/Lockb0x.Certificates.csproj
@@ -5,8 +5,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-    <ItemGroup>
-      <ProjectReference Include="..\Lockb0x.Core\Lockb0x.Core.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Lockb0x.Core\Lockb0x.Core.csproj" />
+    <ProjectReference Include="..\Lockb0x.Signing\Lockb0x.Signing.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/Lockb0x.Certificates/Models/CertificateModels.cs
+++ b/Lockb0x.Certificates/Models/CertificateModels.cs
@@ -1,0 +1,255 @@
+using System.Collections.ObjectModel;
+using System.Linq;
+using Lockb0x.Core.Models;
+using Lockb0x.Signing;
+
+namespace Lockb0x.Certificates.Models;
+
+/// <summary>
+/// Enumerates the supported certificate formats defined by the Lockb0x protocol specification.
+/// </summary>
+public enum CertificateFormat
+{
+    Json,
+    VerifiableCredential,
+    Jwt,
+    Cwt,
+    X509
+}
+
+/// <summary>
+/// Enumerates the supported certificate purposes.
+/// </summary>
+public enum CertificatePurpose
+{
+    Attestation,
+    Provenance,
+    Audit
+}
+
+/// <summary>
+/// Represents the lifecycle status of a certificate.
+/// </summary>
+public enum CertificateStatus
+{
+    Active,
+    Revoked,
+    Expired
+}
+
+/// <summary>
+/// Captures audit events recorded for a certificate.
+/// </summary>
+/// <param name="Type">A short machine readable event type (e.g. <c>issued</c>, <c>revoked</c>).</param>
+/// <param name="Timestamp">The time at which the event occurred.</param>
+/// <param name="Message">A human readable message describing the event.</param>
+/// <param name="Actor">Optional identity of the actor who triggered the event.</param>
+public sealed record CertificateEvent(string Type, DateTimeOffset Timestamp, string Message, string? Actor = null);
+
+/// <summary>
+/// Represents the immutable descriptor returned when issuing or retrieving a certificate.
+/// </summary>
+public sealed record CertificateDescriptor(
+    string CertificateId,
+    string EntryId,
+    string Issuer,
+    string Subject,
+    CertificatePurpose Purpose,
+    DateTimeOffset IssuedAt,
+    DateTimeOffset? ExpiresAt,
+    CertificateStatus Status,
+    IReadOnlyList<CertificateRepresentation> Representations,
+    IReadOnlyList<CertificateEvent> Events
+)
+{
+    public CertificateDescriptor WithStatus(CertificateStatus status, IEnumerable<CertificateEvent>? additionalEvents = null)
+    {
+        if (status == Status && additionalEvents is null)
+        {
+            return this;
+        }
+
+        var events = Events.ToList();
+        if (additionalEvents is not null)
+        {
+            events.AddRange(additionalEvents);
+        }
+
+        return this with
+        {
+            Status = status,
+            Events = new ReadOnlyCollection<CertificateEvent>(events)
+        };
+    }
+}
+
+/// <summary>
+/// Represents the inputs required to issue a certificate.
+/// </summary>
+public sealed class CertificateOptions
+{
+    private IReadOnlyCollection<CertificateFormat>? _formats;
+    private IReadOnlyDictionary<string, string>? _additionalMetadata;
+    private IReadOnlyCollection<string>? _vcContexts;
+
+    /// <summary>
+    /// Gets or sets the intended certificate purpose. Defaults to <see cref="CertificatePurpose.Attestation"/>.
+    /// </summary>
+    public CertificatePurpose Purpose { get; init; } = CertificatePurpose.Attestation;
+
+    /// <summary>
+    /// Gets or sets the formats to emit. Defaults to JSON, JWT, and Verifiable Credential.
+    /// </summary>
+    public IReadOnlyCollection<CertificateFormat> Formats
+    {
+        get => _formats ?? DefaultFormats;
+        init => _formats = value ?? DefaultFormats;
+    }
+
+    /// <summary>
+    /// Gets or sets the certificate issuer identifier. Defaults to <c>entry.Identity.Org</c>.
+    /// </summary>
+    public string? Issuer { get; init; }
+
+    /// <summary>
+    /// Gets or sets the certificate subject identifier. Defaults to <c>entry.Identity.Subject</c> or <c>entry.Id</c>.
+    /// </summary>
+    public string? Subject { get; init; }
+
+    /// <summary>
+    /// Gets or sets the optional audience claim for JWT/CWT representations.
+    /// </summary>
+    public string? Audience { get; init; }
+
+    /// <summary>
+    /// Gets or sets the certificate validity end time.
+    /// </summary>
+    public DateTimeOffset? ExpiresAt { get; init; }
+
+    /// <summary>
+    /// Gets or sets the custom issuance time. Defaults to <see cref="DateTimeOffset.UtcNow"/>.
+    /// </summary>
+    public DateTimeOffset? IssuedAt { get; init; }
+
+    /// <summary>
+    /// Gets or sets the semantic protocol version string written into JSON certificates.
+    /// Defaults to the Codex entry version when omitted.
+    /// </summary>
+    public string? ProtocolVersion { get; init; }
+
+    /// <summary>
+    /// Gets or sets optional additional metadata to embed into the JSON certificate representation.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? AdditionalMetadata
+    {
+        get => _additionalMetadata;
+        init => _additionalMetadata = value is null ? null : new ReadOnlyDictionary<string, string>(value.ToDictionary(kv => kv.Key, kv => kv.Value));
+    }
+
+    /// <summary>
+    /// Gets or sets the JSON-LD contexts for Verifiable Credential representations.
+    /// </summary>
+    public IReadOnlyCollection<string> VerifiableCredentialContexts
+    {
+        get => _vcContexts ?? DefaultVcContexts;
+        init => _vcContexts = value ?? DefaultVcContexts;
+    }
+
+    /// <summary>
+    /// Gets or sets the signing algorithm to use. Defaults to <c>EdDSA</c>.
+    /// </summary>
+    public string SigningAlgorithm { get; init; } = "EdDSA";
+
+    /// <summary>
+    /// Gets or sets the signing key used to create signatures across representations.
+    /// </summary>
+    public required SigningKey SigningKey { get; init; }
+
+    /// <summary>
+    /// Optional custom certificate identifier. When omitted, a UUIDv4 URN is generated.
+    /// </summary>
+    public string? CertificateId { get; init; }
+
+    private static readonly IReadOnlyCollection<CertificateFormat> DefaultFormats = new ReadOnlyCollection<CertificateFormat>(new[]
+    {
+        CertificateFormat.Json,
+        CertificateFormat.Jwt,
+        CertificateFormat.VerifiableCredential
+    });
+
+    private static readonly IReadOnlyCollection<string> DefaultVcContexts = new ReadOnlyCollection<string>(new[]
+    {
+        "https://www.w3.org/2018/credentials/v1",
+        "https://w3id.org/security/suites/ed25519-2020/v1",
+        "https://lockb0x.org/contexts/lockb0x-certificate-v1"
+    });
+}
+
+/// <summary>
+/// Base type for issued certificate payloads.
+/// </summary>
+public abstract record CertificateRepresentation(CertificateFormat Format, string MediaType);
+
+public sealed record JsonCertificateRepresentation(
+    string Json,
+    string CanonicalForm,
+    SignatureProof Signature,
+    string ProtocolVersion,
+    string EntryHash
+) : CertificateRepresentation(CertificateFormat.Json, "application/lockb0x+json");
+
+public sealed record VerifiableCredentialRepresentation(
+    string Credential,
+    string CanonicalForm,
+    SignatureProof Proof,
+    IReadOnlyCollection<string> Contexts,
+    string EntryHash,
+    string Jws
+) : CertificateRepresentation(CertificateFormat.VerifiableCredential, "application/ld+json");
+
+public sealed record JwtCertificateRepresentation(
+    string Token,
+    string Header,
+    string Payload,
+    SignatureProof Signature,
+    string EntryHash
+) : CertificateRepresentation(CertificateFormat.Jwt, "application/jwt");
+
+public sealed record CwtCertificateRepresentation(
+    byte[] Payload,
+    SignatureProof Signature,
+    string EntryHash
+) : CertificateRepresentation(CertificateFormat.Cwt, "application/cwt");
+
+public sealed record X509CertificateRepresentation(
+    byte[] Certificate,
+    string EntryHashAlgorithm,
+    byte[] EntryHash
+) : CertificateRepresentation(CertificateFormat.X509, "application/pkix-cert");
+
+/// <summary>
+/// Represents the result of validating a certificate against a Codex entry.
+/// </summary>
+public sealed class CertificateValidationResult
+{
+    private readonly List<string> _errors = new();
+    private readonly List<string> _warnings = new();
+
+    public bool Success => _errors.Count == 0;
+
+    public IReadOnlyList<string> Errors => _errors;
+
+    public IReadOnlyList<string> Warnings => _warnings;
+
+    public CertificateValidationResult AddError(string message)
+    {
+        _errors.Add(message);
+        return this;
+    }
+
+    public CertificateValidationResult AddWarning(string message)
+    {
+        _warnings.Add(message);
+        return this;
+    }
+}

--- a/Lockb0x.Certificates/Stores/ICertificateStore.cs
+++ b/Lockb0x.Certificates/Stores/ICertificateStore.cs
@@ -1,0 +1,15 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Lockb0x.Certificates.Models;
+
+namespace Lockb0x.Certificates.Stores;
+
+/// <summary>
+/// Persists certificate descriptors for retrieval, revocation, and audit history queries.
+/// </summary>
+public interface ICertificateStore
+{
+    Task SaveAsync(CertificateDescriptor descriptor, CancellationToken cancellationToken = default);
+    Task<CertificateDescriptor?> GetAsync(string certificateId, CancellationToken cancellationToken = default);
+    Task UpdateAsync(CertificateDescriptor descriptor, CancellationToken cancellationToken = default);
+}

--- a/Lockb0x.Certificates/Stores/InMemoryCertificateStore.cs
+++ b/Lockb0x.Certificates/Stores/InMemoryCertificateStore.cs
@@ -1,0 +1,43 @@
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Lockb0x.Certificates.Models;
+
+namespace Lockb0x.Certificates.Stores;
+
+/// <summary>
+/// Simple in-memory certificate store suitable for tests and reference deployments.
+/// </summary>
+public sealed class InMemoryCertificateStore : ICertificateStore
+{
+    private readonly ConcurrentDictionary<string, CertificateDescriptor> _certificates = new(StringComparer.Ordinal);
+
+    public Task SaveAsync(CertificateDescriptor descriptor, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+        if (!_certificates.TryAdd(descriptor.CertificateId, descriptor))
+        {
+            throw new InvalidOperationException($"A certificate with id '{descriptor.CertificateId}' already exists.");
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task<CertificateDescriptor?> GetAsync(string certificateId, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(certificateId))
+        {
+            return Task.FromResult<CertificateDescriptor?>(null);
+        }
+
+        _certificates.TryGetValue(certificateId, out var descriptor);
+        return Task.FromResult(descriptor);
+    }
+
+    public Task UpdateAsync(CertificateDescriptor descriptor, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+        _certificates[descriptor.CertificateId] = descriptor;
+        return Task.CompletedTask;
+    }
+}

--- a/Lockb0x.Tests/CertificateServiceTests.cs
+++ b/Lockb0x.Tests/CertificateServiceTests.cs
@@ -1,1 +1,272 @@
-// File removed: not implemented in current state.
+using System;
+using System.Collections.Generic;
+using System.Formats.Cbor;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Lockb0x.Certificates;
+using Lockb0x.Certificates.Models;
+using Lockb0x.Core.Models;
+using Lockb0x.Core.Utilities;
+using Lockb0x.Signing;
+using Xunit;
+
+namespace Lockb0x.Tests;
+
+public class CertificateServiceTests
+{
+    [Fact]
+    public async Task IssueCertificate_AllFormats_Succeeds()
+    {
+        var entry = CreateSampleEntry();
+        var service = new CertificateService();
+        var key = CreateEd25519Key("did:example:issuer", "cert-key");
+        var options = new CertificateOptions
+        {
+            SigningKey = key,
+            Issuer = "did:example:issuer",
+            Subject = "did:example:asset",
+            Audience = "lockb0x-tests",
+            ProtocolVersion = "1.0.0",
+            ExpiresAt = DateTimeOffset.UtcNow.AddHours(2),
+            AdditionalMetadata = new Dictionary<string, string>
+            {
+                ["environment"] = "test"
+            },
+            Formats = new[]
+            {
+                CertificateFormat.Json,
+                CertificateFormat.VerifiableCredential,
+                CertificateFormat.Jwt,
+                CertificateFormat.Cwt,
+                CertificateFormat.X509
+            }
+        };
+
+        var descriptor = await service.IssueCertificateAsync(entry, options);
+
+        Assert.Equal(CertificateStatus.Active, descriptor.Status);
+        Assert.Equal(entry.Id, descriptor.EntryId);
+        Assert.Equal("did:example:issuer", descriptor.Issuer);
+        Assert.Equal(5, descriptor.Representations.Count);
+        Assert.Contains(descriptor.Representations, r => r is JsonCertificateRepresentation);
+        Assert.Contains(descriptor.Representations, r => r is VerifiableCredentialRepresentation);
+        Assert.Contains(descriptor.Representations, r => r is JwtCertificateRepresentation);
+        Assert.Contains(descriptor.Representations, r => r is CwtCertificateRepresentation);
+        Assert.Contains(descriptor.Representations, r => r is X509CertificateRepresentation);
+
+        var jsonRep = Assert.IsType<JsonCertificateRepresentation>(descriptor.Representations.First(r => r is JsonCertificateRepresentation));
+        using (var doc = JsonDocument.Parse(jsonRep.Json))
+        {
+            Assert.Equal("lockb0x-json", doc.RootElement.GetProperty("certificate_type").GetString());
+            Assert.Equal(entry.Id, doc.RootElement.GetProperty("codex_entry_id").GetString());
+            Assert.Equal("test", doc.RootElement.GetProperty("additional_metadata").GetProperty("environment").GetString());
+        }
+
+        var vcRep = Assert.IsType<VerifiableCredentialRepresentation>(descriptor.Representations.First(r => r is VerifiableCredentialRepresentation));
+        using (var doc = JsonDocument.Parse(vcRep.Credential))
+        {
+            Assert.Equal(options.VerifiableCredentialContexts.Count, doc.RootElement.GetProperty("@context").GetArrayLength());
+            Assert.Equal(entry.Id, doc.RootElement.GetProperty("credentialSubject").GetProperty("codex_entry_id").GetString());
+        }
+
+        var jwtRep = Assert.IsType<JwtCertificateRepresentation>(descriptor.Representations.First(r => r is JwtCertificateRepresentation));
+        using (var doc = JsonDocument.Parse(jwtRep.Payload))
+        {
+            Assert.Equal(entry.Id, doc.RootElement.GetProperty("codex_entry_id").GetString());
+            Assert.Equal("lockb0x-tests", doc.RootElement.GetProperty("aud").GetString());
+        }
+
+        var cwtRep = Assert.IsType<CwtCertificateRepresentation>(descriptor.Representations.First(r => r is CwtCertificateRepresentation));
+        var reader = new CborReader(cwtRep.Payload);
+        reader.ReadStartMap();
+        byte[]? entryHash = null;
+        while (reader.PeekState() != CborReaderState.EndMap)
+        {
+            var keyId = reader.ReadInt32();
+            if (keyId == 1000)
+            {
+                entryHash = reader.ReadByteString();
+            }
+            else
+            {
+                reader.SkipValue();
+            }
+        }
+        reader.ReadEndMap();
+        Assert.NotNull(entryHash);
+        Assert.NotEmpty(entryHash!);
+
+        var x509Rep = Assert.IsType<X509CertificateRepresentation>(descriptor.Representations.First(r => r is X509CertificateRepresentation));
+        using (var certificate = new X509Certificate2(x509Rep.Certificate))
+        {
+            Assert.Equal("CN=did:example:asset", certificate.Subject);
+            Assert.Equal("CN=did:example:issuer", certificate.Issuer);
+        }
+
+        var validation = await service.ValidateCertificateAsync(descriptor, entry);
+        Assert.True(validation.Success);
+    }
+
+    [Fact]
+    public async Task ValidateCertificateAsync_Fails_ForTamperedEntry()
+    {
+        var entry = CreateSampleEntry();
+        var service = new CertificateService();
+        var options = new CertificateOptions
+        {
+            SigningKey = CreateEd25519Key("did:example:issuer", "cert-key"),
+            Issuer = "did:example:issuer",
+            Subject = "did:example:asset",
+            Formats = new[] { CertificateFormat.Json, CertificateFormat.Jwt }
+        };
+
+        var descriptor = await service.IssueCertificateAsync(entry, options);
+
+        var tampered = new CodexEntryBuilder()
+            .WithId(entry.Id)
+            .WithVersion(entry.Version)
+            .WithStorage(new StorageDescriptor
+            {
+                Protocol = entry.Storage.Protocol,
+                IntegrityProof = entry.Storage.IntegrityProof,
+                MediaType = "application/json",
+                SizeBytes = entry.Storage.SizeBytes,
+                Location = new StorageLocation
+                {
+                    Region = entry.Storage.Location.Region,
+                    Jurisdiction = entry.Storage.Location.Jurisdiction,
+                    Provider = entry.Storage.Location.Provider
+                }
+            })
+            .WithIdentity(new IdentityDescriptor
+            {
+                Org = entry.Identity.Org,
+                Artifact = entry.Identity.Artifact,
+                Subject = entry.Identity.Subject
+            })
+            .WithEncryption(entry.Encryption)
+            .WithTimestamp(entry.Timestamp)
+            .WithAnchor(new AnchorProof
+            {
+                Chain = entry.Anchor.Chain,
+                TransactionHash = entry.Anchor.TransactionHash,
+                HashAlgorithm = entry.Anchor.HashAlgorithm,
+                AnchoredAt = entry.Anchor.AnchoredAt,
+                TokenId = entry.Anchor.TokenId
+            })
+            .WithSignatures(entry.Signatures)
+            .Build();
+
+        var validation = await service.ValidateCertificateAsync(descriptor, tampered);
+        Assert.False(validation.Success);
+        Assert.Contains(validation.Errors, error => error.Contains("hash", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task RevokeCertificateAsync_UpdatesStatusAndPreventsValidation()
+    {
+        var entry = CreateSampleEntry();
+        var service = new CertificateService();
+        var options = new CertificateOptions
+        {
+            SigningKey = CreateEd25519Key("did:example:issuer", "cert-key"),
+            Issuer = "did:example:issuer",
+            Subject = "did:example:asset",
+            Formats = new[] { CertificateFormat.Json }
+        };
+
+        var descriptor = await service.IssueCertificateAsync(entry, options);
+        var revoked = await service.RevokeCertificateAsync(descriptor.CertificateId, "testing revocation");
+
+        Assert.True(revoked);
+
+        var stored = await service.GetCertificateAsync(descriptor.CertificateId);
+        Assert.NotNull(stored);
+        Assert.Equal(CertificateStatus.Revoked, stored!.Status);
+        Assert.Contains(stored.Events, e => e.Type == "revoked");
+
+        var validation = await service.ValidateCertificateAsync(stored, entry);
+        Assert.False(validation.Success);
+        Assert.Contains(validation.Errors, error => error.Contains("revoked", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static CodexEntry CreateSampleEntry()
+    {
+        var timestamp = DateTimeOffset.UtcNow;
+        return new CodexEntryBuilder()
+            .WithId(Guid.NewGuid())
+            .WithVersion("1.0.0")
+            .WithStorage(new StorageDescriptor
+            {
+                Protocol = "gcs",
+                IntegrityProof = NiUri.Create(new byte[] { 1, 2, 3, 4 }),
+                MediaType = "application/pdf",
+                SizeBytes = 4096,
+                Location = new StorageLocation
+                {
+                    Region = "us-central1",
+                    Jurisdiction = "US",
+                    Provider = "Lockb0x Storage"
+                }
+            })
+            .WithEncryption(new EncryptionDescriptor
+            {
+                Algorithm = "AES-256-GCM",
+                KeyOwnership = "did:example:issuer#key",
+                Policy = new EncryptionPolicy
+                {
+                    Type = "threshold",
+                    Threshold = 1,
+                    Total = 1
+                },
+                PublicKeys = new[] { "did:example:issuer#key" },
+                LastControlledBy = new List<string> { "did:example:issuer#key" }
+            })
+            .WithIdentity(new IdentityDescriptor
+            {
+                Org = "did:example:issuer",
+                Artifact = "Lockb0x Reference Artifact",
+                Subject = "did:example:asset"
+            })
+            .WithTimestamp(timestamp)
+            .WithAnchor(new AnchorProof
+            {
+                Chain = "stellar:pubnet",
+                TransactionHash = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+                HashAlgorithm = "sha-256",
+                AnchoredAt = timestamp,
+                TokenId = "lockb0x-token"
+            })
+            .WithSignatures(new[]
+            {
+                new SignatureProof
+                {
+                    ProtectedHeader = new SignatureProtectedHeader
+                    {
+                        Algorithm = "EdDSA",
+                        KeyId = "entry-signer"
+                    },
+                    Signature = Convert.ToBase64String(Encoding.UTF8.GetBytes("entry-signature"))
+                }
+            })
+            .Build();
+    }
+
+    private static SigningKey CreateEd25519Key(string controller, string keyId)
+    {
+        var privateKeyHex = "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60";
+        var publicKeyHex = "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a";
+
+        return new SigningKey
+        {
+            KeyId = keyId,
+            Type = "EdDSA",
+            Controller = controller,
+            PrivateKey = Convert.ToBase64String(Convert.FromHexString(privateKeyHex)),
+            PublicKey = Convert.ToBase64String(Convert.FromHexString(publicKeyHex))
+        };
+    }
+}

--- a/Lockb0x.Tests/Lockb0x.Tests.csproj
+++ b/Lockb0x.Tests/Lockb0x.Tests.csproj
@@ -10,6 +10,7 @@
   <ProjectReference Include="..\Lockb0x.Anchor.Stellar\Lockb0x.Anchor.Stellar.csproj" />
   <ProjectReference Include="..\Lockb0x.Core\Lockb0x.Core.csproj" />
   <ProjectReference Include="..\Lockb0x.Signing\Lockb0x.Signing.csproj" />
+  <ProjectReference Include="..\Lockb0x.Certificates\Lockb0x.Certificates.csproj" />
     <ProjectReference Include="..\Lockb0x.Storage\Lockb0x.Storage.csproj" />
     </ItemGroup>
 


### PR DESCRIPTION
## Summary
- implement a full-featured certificate service with JSON, VC, JWT, CWT, and X.509 representations and in-memory persistence
- define certificate data models, validation results, and issuance options aligned with the protocol specification
- add comprehensive unit tests covering issuance, validation failures, and revocation flows

## Testing
- not run (dotnet CLI unavailable in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68df1d158f1c832d80a18262b12b053b