### PR TITLE
Add sponsor documentation and support pathways

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,6 @@
+github: lockb0x-llc
+open_collective: lockb0x
+ko_fi: lockb0x
+patreon: lockb0x
+custom:
+  - https://lockb0x.io/donate

--- a/.github/ISSUE_TEMPLATE/paid-support.yml
+++ b/.github/ISSUE_TEMPLATE/paid-support.yml
@@ -1,0 +1,33 @@
+name: "💼 Paid Support / Enterprise Inquiry"
+description: Route requests that require SLAs or integration time.
+title: "[Support] <brief description>"
+labels: ["paid-support"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reaching out! If this is a **bug** or **feature request** for the open-source repo, please use the standard templates.
+        If you need **commercial support** (SLAs, consulting, roadmap input), please complete the form below.
+  - type: textarea
+    id: need
+    attributes:
+      label: What do you need?
+      placeholder: e.g., integration help with Filecoin adapter; timeline; scope
+  - type: input
+    id: company
+    attributes:
+      label: Company / Team
+  - type: input
+    id: contact
+    attributes:
+      label: Contact email
+  - type: dropdown
+    id: tier
+    attributes:
+      label: Are you already a sponsor?
+      options:
+        - "No"
+        - "Yes - Community"
+        - "Yes - Builder"
+        - "Yes - Team"
+        - "Yes - Enterprise"

--- a/.gitignore
+++ b/.gitignore
@@ -108,7 +108,9 @@ Thumbs.db
 # MCP and development tooling configs
 .msp.json
 .vscode/
-.github/
+# Allow repository metadata (issue templates, funding, etc.)
+!.github/
+!.github/**
 
 # Exclude secrets and sensitive files
 .env
@@ -123,3 +125,10 @@ secrets.json
 !CONTRIBUTING.md
 !CODE_OF_CONDUCT.md
 !SETUP.md
+
+# Grant management artifacts (ignore sensitive contents by default)
+grant-management/**
+!grant-management/
+!grant-management/README.md
+!grant-management/*/
+!grant-management/**/README.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ We welcome contributions from the community to help improve the specification, r
 - **Issues:**
   - Use the [GitHub Issues](https://github.com/lockb0x-llc/lockb0x-protocol/issues) tab to ask questions, discuss ideas, or report bugs.
   - Please search existing issues before opening a new one.
+  - Need guaranteed timelines, integration help, or training? See **[SUPPORT.md](./SUPPORT.md)** for commercial options.
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,29 @@
 
 # Lockb0x Protocol
 
+[![Sponsor](https://img.shields.io/badge/Sponsor-Lockb0x%20Protocol-pink.svg)](https://github.com/sponsors/lockb0x-llc)
+
 The **Lockb0x Protocol** is an open standard for proving the **existence, integrity, and custodianship** of digital data.
 It’s designed for developers who need **verifiable audit trails** without locking into a single vendor, storage backend, or blockchain.
+
+## 💚 Support Lockb0x Protocol
+
+Lockb0x is an open, standards-first protocol for verifiable data sovereignty.
+If this project helps you, please consider sponsoring to sustain maintenance and new features.
+
+[⬆️ Become a Sponsor](https://github.com/sponsors/lockb0x-llc)
+·
+[📄 Commercial Support](./SUPPORT.md)
+·
+[🤝 Contributors](./CONTRIBUTING.md)
+
+---
+
+### Sponsor Tiers (high level)
+- **Community ($5/mo)** – Name listed in [SPONSORS.md](./SPONSORS.md)
+- **Builder ($25/mo)** – Priority tag on one issue per month
+- **Team ($250/mo)** – 1h/mo integration Q&A + logo here
+- **Enterprise ($2,000/mo)** – 4h/mo solutioning + feature prioritization window
 
 At its core, Lockb0x provides a portable, signed JSON structure called a **Codex Entry**.
 Each entry links together:

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -1,0 +1,14 @@
+# Sponsors
+
+A sincere thank-you to everyone who sponsors the Lockb0x Protocol.  
+To be listed here, sponsor via GitHub Sponsors and opt-in to recognition.
+
+## Individuals
+- _Your name here_
+
+## Organizations
+| Logo | Name | Tier |
+|-----|------|------|
+| (logo) | Example Corp | Team |
+
+(If you later want this list to update automatically, you can add a small GitHub Action that syncs your sponsors—optional.)

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,14 @@
+# Commercial Support & Sponsorship
+
+Lockb0x is open-source and free to use. For teams that need **SLAs, integration help, or roadmap input**, we offer paid options.
+
+## Options
+- **Sponsor Tiers:** via GitHub Sponsors – lightweight ongoing support.
+- **Enterprise Support:** guaranteed response SLAs, roadmap input, and limited integration assistance.
+
+## Contact
+- 📧 support@lockb0x.io
+- 💸 Sponsors: https://github.com/sponsors/lockb0x-llc
+- 🔒 Enterprise: see [docs/commercial/README.md](./docs/commercial/README.md)
+
+> Security issues? Please use our **[SECURITY.md](./SECURITY.md)** policy and private channel.

--- a/docs/commercial/README.md
+++ b/docs/commercial/README.md
@@ -1,0 +1,10 @@
+# Lockb0x Commercial Options
+
+**What stays free:** the protocol spec, reference implementations, schemas, and examples.
+
+**What you can pay for (optional):**
+- **SLAs & Support Hours:** incident & integration assistance
+- **Feature Prioritization Windows:** queue time reserved for sponsors
+- **Workshops:** 2–4 hour architecture workshops for your team
+
+**How to start:** sponsor us on GitHub or email enterprise@lockb0x.io.

--- a/grant-management/GG24/README.md
+++ b/grant-management/GG24/README.md
@@ -1,0 +1,10 @@
+# GG24 Grant
+
+This directory collects planning notes, deliverables, and reporting details for the GG24 grant track.
+
+Suggested documents:
+- Grant narrative drafts
+- KPI tracking and status updates
+- Partnership or stakeholder coordination notes
+
+> Store confidential application data in private systems and only commit public-ready summaries here.

--- a/grant-management/README.md
+++ b/grant-management/README.md
@@ -1,0 +1,8 @@
+# Grant Management
+
+This directory tracks grants and funding initiatives related to the Lockb0x Protocol.
+
+- [`chrome-extension-hackathon/`](./chrome-extension-hackathon/) — materials and planning notes for the Chrome Extension Hackathon grant.
+- [`GG24/`](./GG24/) — documentation for the GG24 grant application and reporting.
+
+> Sensitive financial or personal information should be stored securely outside of the repository.

--- a/grant-management/chrome-extension-hackathon/README.md
+++ b/grant-management/chrome-extension-hackathon/README.md
@@ -1,0 +1,10 @@
+# Chrome Extension Hackathon Grant
+
+Use this folder to track proposals, milestones, and deliverables for the Chrome Extension Hackathon grant opportunity.
+
+Recommended contents:
+- Project timeline and milestone notes
+- Budget breakdowns (excluding sensitive data)
+- Meeting summaries and decisions
+
+> Keep confidential information in secure private storage systems.


### PR DESCRIPTION
## Summary
- add GitHub Sponsors configuration and paid support issue template
- document sponsorship tiers and commercial support details in README, SUPPORT, and SPONSORS files
- introduce grant management placeholders and commercial docs with gitignore rules

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e46fb26024832d9b36460211becdc8